### PR TITLE
Add Supabase client and env vars

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -22,3 +22,7 @@ DATABASE_URL=postgresql://postgres.wxdzsxzwelqmrfwizici:mybibleapp123@aws-0-us-e
 
 # API.Bible key
 BIBLE_API_KEY=6e42642dbc62c69e4de384dea62b1490
+
+# Supabase credentials used by frontend
+# VITE_SUPABASE_URL=
+# VITE_SUPABASE_ANON_KEY=

--- a/src/.env
+++ b/src/.env
@@ -22,3 +22,7 @@ DATABASE_URL=postgresql://postgres.wxdzsxzwelqmrfwizici:mybibleapp123@aws-0-us-e
 
 # API.Bible key
 BIBLE_API_KEY=6e42642dbc62c69e4de384dea62b1490
+
+# Supabase credentials
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add Supabase credentials placeholders to `src/.env`
- document same variables in `backend/.env`
- create `src/lib/supabaseClient.ts` for centralized Supabase access

## Testing
- `npm test` *(fails: Missing script)*
- `npx vite build` *(fails: needs confirmation for package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6866ffc42b808330844e742f81ace843