### PR TITLE
Add simple auth context with verification

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState } from "react";
+
+export interface AuthContextType {
+  isVerified: boolean;
+  setIsVerified: (v: boolean) => void;
+  profile: any;
+  setProfile: (p: any) => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isVerified, setIsVerified] = useState(false);
+  const [profile, setProfile] = useState<any>(null);
+
+  return (
+    <AuthContext.Provider value={{ isVerified, setIsVerified, profile, setProfile }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+};

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -6,6 +6,7 @@ import {
 import { HTMLElementRefOf } from "@plasmicapp/react-web";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../lib/supabaseClient";
+import { useAuth } from "../AuthContext";
 
 export interface LoginProps extends DefaultLoginProps {}
 
@@ -13,7 +14,7 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
   const navigate = useNavigate();
   const [phone, setPhone] = React.useState("");
   const [code, setCode] = React.useState("");
-  const [profile, setProfile] = React.useState<any>(null);
+  const { setProfile, setIsVerified } = useAuth();
 
   const handleSend = async () => {
     console.log("[handleSend] Invoked");
@@ -78,6 +79,8 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
         } else {
           setProfile(profileData);
         }
+
+        setIsVerified(true);
 
         navigate('/profile');
       } else {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,16 @@ import App from "./App";
 import { PlasmicRootProvider } from "@plasmicapp/loader-react";
 import { BrowserRouter } from "react-router-dom";
 import { PLASMIC } from "./plasmic-init";
+import { AuthProvider } from "./AuthContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <PlasmicRootProvider loader={PLASMIC}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
     </PlasmicRootProvider>
   </React.StrictMode>
 );

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 import PageLayoutWrapper from "../components/PageLayoutWrapper";
 import { PlasmicComponent } from "@plasmicapp/loader-react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../AuthContext";
 
 export default function ProfilePage() {
+  const { isVerified } = useAuth();
+
+  if (!isVerified) {
+    return <Navigate to="/login" replace />;
+  }
+
   return (
     <PageLayoutWrapper>
       <PlasmicComponent component="Profile" />


### PR DESCRIPTION
## Summary
- set up `AuthContext` for global verification state and profile
- update login flow to set `isVerified` on successful verification
- protect `ProfilePage` with redirect to `/login`
- wrap app in `AuthProvider` to supply context

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867084aae848330a44b8b7ad67dee64