### PR TITLE
Add code to send-code response

### DIFF
--- a/backend/routes/send-code.js
+++ b/backend/routes/send-code.js
@@ -36,7 +36,7 @@ router.post("/", async (req, res) => {
     });
 
     console.log("[/api/send-code] Message SID:", message.sid);
-    res.json({ success: true, phone, codeSent: true });
+    res.json({ success: true, phone, codeSent: true, code });
   } catch (err) {
     console.error("[/api/send-code] Error:", err);
     res.status(500).json({ success: false, error: err.message });


### PR DESCRIPTION
## Summary
- include the generated verification code when sending SMS codes so the frontend can display it

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68670e99fa448330b3ed25e0f687320a