### PR TITLE
Remove Twilio credential logs

### DIFF
--- a/backend/routes/send-code.js
+++ b/backend/routes/send-code.js
@@ -7,14 +7,16 @@ const accountSid = process.env.TWILIO_SID;
 const authToken = process.env.TWILIO_AUTH_TOKEN;
 const serviceSid = process.env.TWILIO_VERIFY;
 
-console.log("[DEBUG] TWILIO_SID:", accountSid);
-console.log("[DEBUG] TWILIO_AUTH_TOKEN:", authToken);
+// Avoid logging sensitive values directly
+console.log("[DEBUG] TWILIO_SID loaded");
+console.log("[DEBUG] TWILIO_AUTH_TOKEN loaded");
 
 const client = twilio(accountSid, authToken);
 
 router.post("/", async (req, res) => {
   let { phone } = req.body;
-  console.log("[/api/send-code] Received phone:", phone);
+  // Mask phone number when logging
+  console.log("[/api/send-code] Received phone");
 
   // Normalize to E.164 format if needed
   if (!phone.startsWith("+1")) {


### PR DESCRIPTION
## Summary
- mask Twilio SID and Auth Token logging
- hide phone number output in the send code endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68671048410c83309493c5823fef2d62