### PR TITLE
Add null handling for Supabase

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -68,6 +68,11 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
       console.log("[handleVerify] Response:", data);
 
       if (data.success) {
+        if (!supabase) {
+          console.error('[handleVerify] Supabase client is not initialized');
+          return;
+        }
+
         const { data: profileData, error } = await supabase
           .from('profiles')
           .select('*')

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -20,6 +20,12 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
       if (!authProfile?.phone) {
         return;
       }
+
+      if (!supabase) {
+        console.error("[fetchProfile] Supabase client is not initialized");
+        return;
+      }
+
       const { data, error } = await supabase
         .from("profiles")
         .select("*")
@@ -40,6 +46,12 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
   }, [authProfile?.phone]);
 
   const handleSave = async () => {
+    if (!supabase) {
+      console.error("[handleSave] Supabase client is not initialized");
+      alert("Supabase client is not available.");
+      return;
+    }
+
     const { error } = await supabase.from("profiles").upsert({
       phone,
       name,

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,14 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export let supabase: SupabaseClient | null = null;
+
+if (supabaseUrl && supabaseAnonKey) {
+  supabase = createClient(supabaseUrl, supabaseAnonKey);
+} else {
+  console.error(
+    'Supabase credentials are missing. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.'
+  );
+}


### PR DESCRIPTION
## Summary
- handle missing Supabase credentials in `supabaseClient`
- guard Supabase usage in `Profile` and `Login` components

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867189469888330ba59aaf5f757eaf1