### PR TITLE
Add backend start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The server runs on port `5173` by default.
 In another terminal, start the backend API:
 ```bash
 cd backend
-node index.js
+npm start
 ```
 The backend listens on the port specified in `backend/.env` (default `5000`).
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- define a `start` script in `backend/package.json`
- document using `npm start` to run the API

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686719c637188330af3c55d842deb774