### PR TITLE
Add tsconfig for TypeScript support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": [
+    "src",
+    "vite.config.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a TypeScript config with React/Vite settings

## Testing
- `npm install`
- `npx tsc --noEmit` *(fails: Type '{ navbar: { children: Element; }; children: ReactNode; }' is not assignable to type '"Unexpected extraneous props"')*

------
https://chatgpt.com/codex/tasks/task_e_68671a3e89788330a0c3b39d8bb32bcb