### PR TITLE
Fix phone normalization in verify-code

### DIFF
--- a/backend/routes/verify-code.js
+++ b/backend/routes/verify-code.js
@@ -10,7 +10,12 @@ const serviceSid = process.env.TWILIO_VERIFY;
 const client = twilio(accountSid, authToken);
 
 router.post("/", async (req, res) => {
-  const { phone, code } = req.body;
+  let { phone, code } = req.body;
+
+  // Normalize to E.164 format if needed (consistent with send-code.js)
+  if (!phone.startsWith("+1")) {
+    phone = "+1" + phone.replace(/\D/g, "");
+  }
 
   if (!phone || !code) {
     return res.status(400).json({ error: "Missing phone or code" });


### PR DESCRIPTION
## Summary
- normalize the phone number in `verify-code` the same as in `send-code`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68671f09ab7c8330a238a40f8e1fef5f