### PR TITLE
Persist sanitized phone in login

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -37,7 +37,8 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
       console.log("[handleSend] Response:", data);
 
       if (data.success) {
-        alert(`Verification code sent to ${phone} — CODE: ${data.code}`);
+        setPhone(data.phone);
+        alert(`Verification code sent to ${data.phone} — CODE: ${data.code}`);
       } else {
         alert(`Failed to send: ${data.error}`);
       }


### PR DESCRIPTION
## Summary
- store the E.164 phone returned by the backend when sending the verification code
- use this value for subsequent verification

## Testing
- `npm install --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686722b035d08330aaa32d49096fb0f1