### PR TITLE
Remove secrets and document env setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 
+
+.env

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project contains a Vite based React frontend and a simple Express backend.
    cp src/.env.example src/.env
    cp backend/.env.example backend/.env
    ```
+   After copying, open these files and replace the placeholder values with your own credentials. The `.env` files are ignored by git thanks to the `.env` entry in `.gitignore`.
 
    The following environment variables are required:
 

--- a/backend/.env
+++ b/backend/.env
@@ -2,28 +2,21 @@
 PORT=5000
 
 # Twilio Credentials
-TWILIO_VERIFY=VAdd281d2f09c45e85e9ad9466b2ef3929
-TWILIO_SID=ACba43e938d7270668a6c8758b35a362db
-TWILIO_AUTH_TOKEN=4417474033a384c2bfe39cad1eec9b8e
-TWILIO_PHONE_NUMBER=+17275917765
+TWILIO_VERIFY=
+TWILIO_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=
 
 # PostgreSQL Database Connection URL
-# Local options for testing:
-DATABASE_URL=postgresql://postgres:mybibleapp123@host.docker.internal:5433/mydb
-DATABASE_URL=postgresql://postgres:mybibleapp123@localhost:5432/mydb
-DATABASE_URL=postgresql://postgres:mybibleapp123@localhost:5433/mydb
-# Supabase direct:
-DATABASE_URL=postgresql://postgres:mybibleapp123@db.wxdzsxzwelqmrfwizici.supabase.co:5432/postgres
-# Supabase pooled (previous):
-DATABASE_URL=postgresql://postgres.wxdzsxzwelqmrfwizici:mybibleapp123@aws-0-us-east-2.pooler.supabase.com:6543/postgres
-
-# ✅ Fixed Supabase pooled connection string (with pgbouncer + no prepared statements)
-DATABASE_URL=postgresql://postgres.wxdzsxzwelqmrfwizici:mybibleapp123@aws-0-us-east-2.pooler.supabase.com:6543/postgres?pgbouncer=true&statement_cache_size=0
+DATABASE_URL=
 
 # API.Bible key
-BIBLE_API_KEY=6e42642dbc62c69e4de384dea62b1490
+BIBLE_API_KEY=
 
 # Supabase credentials used by frontend
 # VITE_SUPABASE_URL=
 # VITE_SUPABASE_ANON_KEY=
 
+# Plasmic credentials used by frontend
+# PLASMIC_PROJECT_ID=
+# PLASMIC_PUBLIC_TOKEN=

--- a/src/.env
+++ b/src/.env
@@ -2,28 +2,21 @@
 PORT=8080
 
 # Twilio Credentials
-TWILIO_VERIFY=VAdd281d2f09c45e85e9ad9466b2ef3929
-TWILIO_SID=ACba43e938d7270668a6c8758b35a362db
-TWILIO_AUTH_TOKEN=4aacb429a7d0105a48cee5ce5092a993
-TWILIO_PHONE_NUMBER=+17275917765
+TWILIO_VERIFY=
+TWILIO_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=
 
 # PostgreSQL Database Connection URL
-# Local options for testing:
-DATABASE_URL=postgresql://postgres:mybibleapp123@host.docker.internal:5433/mydb
-DATABASE_URL=postgresql://postgres:mybibleapp123@localhost:5432/mydb
-DATABASE_URL=postgresql://postgres:mybibleapp123@localhost:5433/mydb
-# Supabase direct:
-DATABASE_URL=postgresql://postgres:mybibleapp123@db.wxdzsxzwelqmrfwizici.supabase.co:5432/postgres
-# Supabase pooled (previous):
-DATABASE_URL=postgresql://postgres.wxdzsxzwelqmrfwizici:mybibleapp123@aws-0-us-east-2.pooler.supabase.com:6543/postgres
-
-# ✅ Fixed Supabase pooled connection string (with pgbouncer + no prepared statements)
-DATABASE_URL=postgresql://postgres.wxdzsxzwelqmrfwizici:mybibleapp123@aws-0-us-east-2.pooler.supabase.com:6543/postgres?pgbouncer=true&statement_cache_size=0
+DATABASE_URL=
 
 # API.Bible key
-BIBLE_API_KEY=6e42642dbc62c69e4de384dea62b1490
+BIBLE_API_KEY=
 
 # Supabase credentials
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 
+# Plasmic credentials
+PLASMIC_PROJECT_ID=
+PLASMIC_PUBLIC_TOKEN=


### PR DESCRIPTION
## Summary
- strip credentials from src/.env and backend/.env
- ignore all .env files
- explain how to use the example env files

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867235d12408330b6c7d7b627970bae