### PR TITLE
Document DATABASE_URL options

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -8,6 +8,9 @@ TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
 
 # PostgreSQL Database Connection URL
+# Use this when connecting to a local Postgres instance
+# DATABASE_URL=postgresql://user:password@localhost:5432/mydb
+# Use this when connecting to your hosted Supabase database
 DATABASE_URL=
 
 # API.Bible key

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,9 @@ TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
 
 # PostgreSQL Database Connection URL
+# Use this when connecting to a local Postgres instance
+# DATABASE_URL=postgresql://user:password@localhost:5432/mydb
+# Use this when connecting to your hosted Supabase database
 DATABASE_URL=
 
 # API.Bible key

--- a/src/.env
+++ b/src/.env
@@ -8,6 +8,9 @@ TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
 
 # PostgreSQL Database Connection URL
+# Use this when connecting to a local Postgres instance
+# DATABASE_URL=postgresql://user:password@localhost:5432/mydb
+# Use this when connecting to your hosted Supabase database
 DATABASE_URL=
 
 # API.Bible key

--- a/src/.env.example
+++ b/src/.env.example
@@ -8,6 +8,9 @@ TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
 
 # PostgreSQL Database Connection URL
+# Use this when connecting to a local Postgres instance
+# DATABASE_URL=postgresql://user:password@localhost:5432/mydb
+# Use this when connecting to your hosted Supabase database
 DATABASE_URL=
 
 # API.Bible key


### PR DESCRIPTION
## Summary
- comment example local DATABASE_URL and clarify Supabase default

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867240f15f08330957612bfd2a4010c