### PR TITLE
Use env vars for Plasmic loader

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -20,6 +20,6 @@ BIBLE_API_KEY=
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 
-# Plasmic credentials
+# Plasmic credentials used by `src/plasmic-init.ts`
 PLASMIC_PROJECT_ID=
 PLASMIC_PUBLIC_TOKEN=

--- a/src/plasmic-init.ts
+++ b/src/plasmic-init.ts
@@ -1,11 +1,20 @@
 // src/plasmic-init.ts
 import { initPlasmicLoader } from "@plasmicapp/loader-react";
 
+const projectId = import.meta.env.PLASMIC_PROJECT_ID as string | undefined;
+const publicToken = import.meta.env.PLASMIC_PUBLIC_TOKEN as string | undefined;
+
+if (!projectId || !publicToken) {
+  console.error(
+    "Plasmic credentials are missing. Please set PLASMIC_PROJECT_ID and PLASMIC_PUBLIC_TOKEN."
+  );
+}
+
 export const PLASMIC = initPlasmicLoader({
   projects: [
     {
-      id: "kPtL4UpULb2Exm5C4cyhzL",      // e.g., "abc123"
-      token: "OloXF2aF67tSsoOEJLmaqbUsPBgaC2evrguIgRwZ12zTKiORgoYrxrbZEZNAj6HA65vfknOmvsxHFHRFAwRTTg", // e.g., "xyz456"
+      id: projectId ?? "",
+      token: publicToken ?? "",
     },
   ],
   preview: true, // true for dev environment


### PR DESCRIPTION
## Summary
- load Plasmic project ID and public token from `import.meta.env`
- document Plasmic variables in `src/.env.example`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686727226c748330bca5738a00958be1