### PR TITLE
Add env validation on backend startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ npm start
 ```
 The backend listens on the port specified in `backend/.env` (default `5000`).
 
+The backend now validates that `TWILIO_SID`, `TWILIO_AUTH_TOKEN` and
+`TWILIO_VERIFY` are set before it loads any routes. If any of these
+variables are missing, the server logs an error and exits immediately so
+configuration issues are caught right away.
+

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,6 +7,20 @@ require("dotenv").config();
 const app = express();
 const port = process.env.PORT || 5000;
 
+// Verify critical Twilio environment variables before loading routes
+const requiredTwilioVars = [
+  "TWILIO_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_VERIFY",
+];
+const missingTwilioVars = requiredTwilioVars.filter((v) => !process.env[v]);
+if (missingTwilioVars.length) {
+  console.error(
+    `[server] Missing environment variables: ${missingTwilioVars.join(", ")}`
+  );
+  process.exit(1);
+}
+
 // Middleware
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- check Twilio env vars when starting backend and exit with error if missing
- note the new backend startup check in the README

## Testing
- `npm test` (fails: Missing script)
- `cd backend && npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68672d89468c8330ab5f6d0a8db75ba7