### PR TITLE
Restore env usage and load vars for Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 
+

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ This project contains a Vite based React frontend and a simple Express backend.
    cp src/.env.example src/.env
    cp backend/.env.example backend/.env
    ```
-   After copying, open these files and replace the placeholder values with your own credentials. The `.env` files are ignored by git thanks to the `.env` entry in `.gitignore`.
+   After copying, open these files and replace the placeholder values with your own credentials. These `.env` files contain your secrets, so keep them safe.
 
    The following environment variables are required:
 
    - **Twilio**: `TWILIO_VERIFY`, `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`
-   - **Database**: `DATABASE_URL` (e.g. your Supabase connection string)
+   - **Database**: `DATABASE_URL` (use your Supabase pooled connection string, e.g.
+     `postgresql://<username>:<password>@aws-0-us-east-2.pooler.supabase.com:6543/postgres?pgbouncer=true&statement_cache_size=0`)
    - **API.Bible**: `BIBLE_API_KEY`
    - **Supabase**: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`
    - **Plasmic**: `PLASMIC_PROJECT_ID`, `PLASMIC_PUBLIC_TOKEN`

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,6 +11,8 @@ TWILIO_PHONE_NUMBER=
 # Use this when connecting to a local Postgres instance
 # DATABASE_URL=postgresql://user:password@localhost:5432/mydb
 # Use this when connecting to your hosted Supabase database
+# Example pooled connection string (pgbouncer enabled):
+# DATABASE_URL=postgresql://<username>:<password>@aws-0-us-east-2.pooler.supabase.com:6543/postgres?pgbouncer=true&statement_cache_size=0
 DATABASE_URL=
 
 # API.Bible key

--- a/src/.env.example
+++ b/src/.env.example
@@ -11,6 +11,8 @@ TWILIO_PHONE_NUMBER=
 # Use this when connecting to a local Postgres instance
 # DATABASE_URL=postgresql://user:password@localhost:5432/mydb
 # Use this when connecting to your hosted Supabase database
+# Example pooled connection string (pgbouncer enabled):
+# DATABASE_URL=postgresql://<username>:<password>@aws-0-us-east-2.pooler.supabase.com:6543/postgres?pgbouncer=true&statement_cache_size=0
 DATABASE_URL=
 
 # API.Bible key

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  envDir: './src',
   server: {
     port: 5173,
   },


### PR DESCRIPTION
## Summary
- keep `.env` files in the repo again
- load Vite environment variables from `src/.env`
- update README note about `.env` files

## Testing
- `npm install`
- `cd backend && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d7f0d08883308e849e812bee0512