### PR TITLE
Fix login verified flag when Supabase missing

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -74,6 +74,8 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
         if (!supabase) {
           console.error('[handleVerify] Supabase client is not initialized');
           alert('Verification succeeded, but Supabase is not configured.');
+          setIsVerified(true);
+          navigate('/profile');
           return;
         }
 


### PR DESCRIPTION
## Summary
- allow login to succeed when Supabase credentials aren't provided

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867dff2d7d083309c80917690aaa6c0