### PR TITLE
Fix double navbar on profile page

### DIFF
--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,11 +1,8 @@
 import React from "react";
-import PageLayoutWrapper from "../components/PageLayoutWrapper";
 import Profile from "../components/Profile";
 
 export default function ProfilePage() {
   return (
-    <PageLayoutWrapper>
-      <Profile />
-    </PageLayoutWrapper>
+    <Profile />
   );
 }


### PR DESCRIPTION
## Summary
- remove extra `PageLayoutWrapper` from `ProfilePage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867ef78a5f483308b5f8fc8ade85ac1