### PR TITLE
Fix Supabase client URL parsing

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,29 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { logger } from './logger';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const rawSupabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export function normalizeSupabaseUrl(url?: string): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+  if (/^https?:\/\//.test(url)) {
+    return url;
+  }
+  try {
+    const parsed = new URL(url);
+    const projectMatch = parsed.username.split('.')[1];
+    if (projectMatch) {
+      return `https://${projectMatch}.supabase.co`;
+    }
+  } catch (err) {
+    logger.warn('Failed to parse Supabase URL', err);
+  }
+  return url;
+}
+
+const supabaseUrl = normalizeSupabaseUrl(rawSupabaseUrl);
 
 export let supabase: SupabaseClient | null = null;
 


### PR DESCRIPTION
## Summary
- handle Postgres connection strings by normalizing `VITE_SUPABASE_URL`
- initialize Supabase client with normalized URL

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_686806899ca48330bdb8bd2319b92bf7