### PR TITLE
Fix profile lookup and creation

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -75,6 +75,7 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
         if (!supabase) {
           logger.error('[handleVerify] Supabase client is not initialized');
           alert('Verification succeeded, but Supabase is not configured.');
+          setProfile({ phoneNumber: phone });
           setIsVerified(true);
           navigate('/profile');
           return;
@@ -87,9 +88,21 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
           .single();
 
         if (error) {
-          logger.error('[handleVerify] Supabase error:', error);
-        } else {
+          logger.warn('[handleVerify] Profile not found, creating new');
+          const { data: newProfile, error: insertError } = await supabase
+            .from('UserProfile')
+            .insert({ phoneNumber: phone })
+            .select('*')
+            .single();
+          if (insertError) {
+            logger.error('[handleVerify] Insert error:', insertError);
+          } else {
+            setProfile(newProfile);
+          }
+        } else if (profileData) {
           setProfile(profileData);
+        } else {
+          setProfile({ phoneNumber: phone });
         }
 
         setIsVerified(true);

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -18,7 +18,7 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
 
   React.useEffect(() => {
     const fetchProfile = async () => {
-      if (!authProfile?.phone) {
+      if (!authProfile?.phoneNumber) {
         return;
       }
 
@@ -44,7 +44,7 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
     };
 
     fetchProfile();
-  }, [authProfile?.phone]);
+  }, [authProfile?.phoneNumber]);
 
   const handleSave = async () => {
     if (!supabase) {


### PR DESCRIPTION
## Summary
- fix Profile component's effect to check `phoneNumber`
- during verification, create a UserProfile if none exists and store phone in context
- when Supabase isn't configured, still store phone number in context
- update backend packages for tests

## Testing
- `npm install --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6868302436bc833080802695b309231a