### PR TITLE
Fix Scriptures page rendering

### DIFF
--- a/src/pages/ScripturePage.tsx
+++ b/src/pages/ScripturePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PageLayoutWrapper from "../components/PageLayoutWrapper";
-import { PlasmicComponent } from "@plasmicapp/loader-react";
+import Scriptures from "../components/Scriptures";
 import { logger } from "../lib/logger";
 
 export default function ScripturesPage() {
@@ -9,7 +9,7 @@ export default function ScripturesPage() {
   }, []);
   return (
     <PageLayoutWrapper>
-      <PlasmicComponent component="Scriptures" />
+      <Scriptures />
     </PageLayoutWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- use compiled `Scriptures` component instead of `PlasmicComponent`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68687f39b3a88330a3c7404401bab046