### PR TITLE
Fix Scripture page layout

### DIFF
--- a/src/pages/ScripturePage.tsx
+++ b/src/pages/ScripturePage.tsx
@@ -1,15 +1,10 @@
 import React from "react";
-import PageLayoutWrapper from "../components/PageLayoutWrapper";
 import Scriptures from "../components/Scriptures";
 import { logger } from "../lib/logger";
 
-export default function ScripturesPage() {
+export default function ScripturePage() {
   React.useEffect(() => {
     logger.info("Rendering ScripturePage");
   }, []);
-  return (
-    <PageLayoutWrapper>
-      <Scriptures />
-    </PageLayoutWrapper>
-  );
+  return <Scriptures />;
 }


### PR DESCRIPTION
## Summary
- remove PageLayoutWrapper from `ScripturePage`
- use same pattern as Login/Profile pages

## Testing
- `npm test` (fails until installing backend dependencies)
- `npm install` in backend then run `npm test`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868819da3448330bc7ba475ed201e50