### PR TITLE
Add bible API and display scriptures

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -43,6 +43,14 @@ try {
   logger.error("Failed to load ./routes/verify-code.js", err.message);
 }
 
+try {
+  const biblesRoute = require(path.join(__dirname, "routes", "bibles"));
+  app.use("/api/bibles", biblesRoute);
+  logger.info("Loaded /api/bibles");
+} catch (err) {
+  logger.error("Failed to load ./routes/bibles.js", err.message);
+}
+
 // Start server
 app.listen(port, () => {
   logger.info(`Server listening on port ${port}`);

--- a/backend/routes/bibles.js
+++ b/backend/routes/bibles.js
@@ -1,0 +1,62 @@
+const express = require("express");
+const router = express.Router();
+const fs = require("fs");
+const path = require("path");
+const logger = require("../utils/logger");
+
+const biblesDir = path.join(__dirname, "..", "bibles");
+let versionsCache = null;
+
+function loadVersions() {
+  if (versionsCache) return versionsCache;
+  try {
+    const files = fs
+      .readdirSync(biblesDir)
+      .filter((f) => f.endsWith(".json"));
+    versionsCache = files.map((file) => {
+      const data = JSON.parse(
+        fs.readFileSync(path.join(biblesDir, file), "utf8")
+      );
+      const { name, shortname, module } = data.metadata || {};
+      return { name, shortname, module };
+    });
+    return versionsCache;
+  } catch (err) {
+    logger.error("[bibles] Failed to read versions", err);
+    throw err;
+  }
+}
+
+router.get("/", (req, res) => {
+  try {
+    const versions = loadVersions();
+    res.json(versions);
+  } catch {
+    res.status(500).json({ error: "Failed to load versions" });
+  }
+});
+
+router.get("/:version", (req, res) => {
+  const { version } = req.params;
+  const { book, chapter } = req.query;
+  if (!book || !chapter) {
+    return res.status(400).json({ error: "book and chapter required" });
+  }
+  const filePath = path.join(biblesDir, `${version}.json`);
+  if (!fs.existsSync(filePath)) {
+    return res.status(404).json({ error: "version not found" });
+  }
+  try {
+    const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    const chapNum = parseInt(chapter, 10);
+    const verses = (data.verses || []).filter(
+      (v) => v.book_name === book && v.chapter === chapNum
+    );
+    res.json(verses);
+  } catch (err) {
+    logger.error("[bibles] Error reading", err);
+    res.status(500).json({ error: "failed to read bible" });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- implement `/api/bibles` backend routes to expose bible versions and verses
- load bible routes in backend server
- fetch bible versions on the frontend and display verses when selections are made

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686886f696fc8330bb0d69b98ba26377