### PR TITLE
Fix verses load error with API proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Start the Vite dev server:
 npm run dev
 ```
 The server runs on port `5173` by default.
+Requests starting with `/api` are automatically proxied to the
+backend server at `http://localhost:5000`.
 
 In another terminal, start the backend API:
 ```bash

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   envDir: './src',
   server: {
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      },
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- proxy `/api` requests from Vite dev server to the backend
- document API proxy setup in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68688c09b8d483308ec4e1848e6cde54