### PR TITLE
Auto select first chapter and add logging

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -8,6 +8,7 @@ import {
 import { HTMLElementRefOf } from "@plasmicapp/react-web";
 import { bibleBooks } from "../lib/bibleData";
 import { bibleVersions } from "../lib/bibleVersions";
+import { logger } from "../lib/logger";
 
 interface Verse {
   verse: number;
@@ -41,19 +42,34 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
 
   React.useEffect(() => {
     if (version && book && chapter) {
+      logger.debug(
+        `Fetching verses for ${book} chapter ${chapter} from version ${version}`
+      );
       fetch(
         `/api/bibles/${version}?book=${encodeURIComponent(book)}&chapter=${chapter}`
       )
-        .then((res) => res.json())
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status} ${res.statusText}`);
+          }
+          return res.json();
+        })
         .then((data) => {
           setVerses(data);
           const found = bibleBooks.find((b) => b.name === book);
           if (found) {
-            alert(`Book found: ${found.name} (${found.chapters} chapters)`);
+            logger.debug(
+              `Loaded ${found.name} chapter ${chapter} successfully`
+            );
+            alert(`Loaded ${found.name} chapter ${chapter} successfully`);
+          } else {
+            logger.debug(`Book not in list: ${book}`);
+            alert(`Book "${book}" was not found.`);
           }
         })
         .catch((err) => {
-          console.error("Failed to load verses", err);
+          logger.error("Failed to load verses", err);
+          alert(`Failed to load ${book} chapter ${chapter}: ${err.message}`);
           setVerses([]);
         });
     } else {
@@ -97,8 +113,10 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
             options: bookOptions,
             value: book,
             onChange: (value: any) => {
-              setBook(value as string);
-              setChapter(undefined);
+              const newBook = value as string;
+              logger.debug(`Selected book ${newBook}`);
+              setBook(newBook);
+              setChapter(1);
             },
           },
         }}
@@ -106,7 +124,11 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
           props: {
             options: chapterOptions,
             value: chapter,
-            onChange: (value: any) => setChapter(value as number),
+            onChange: (value: any) => {
+              const chapNum = value as number;
+              logger.debug(`Selected chapter ${chapNum}`);
+              setChapter(chapNum);
+            },
           },
         }}
       />


### PR DESCRIPTION
## Summary
- auto select Chapter 1 when a book is chosen
- log book/chapter selections and fetch result
- show dialog alerts on success or failure

## Testing
- `cd backend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686920f454c48330aaa7865b497e7912