### PR TITLE
Display loaded chapter verses

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -132,7 +132,14 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
           },
         }}
       />
-      <div style={{ padding: "1rem" }}>
+      <div
+        style={{
+          padding: "1rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.5rem",
+        }}
+      >
         {verses.map((v) => (
           <div key={v.verse} style={{ display: "flex", gap: "0.5rem" }}>
             <div style={{ width: "2rem", textAlign: "right" }}>{v.verse}</div>


### PR DESCRIPTION
## Summary
- render verses in a vertical column once the chapter loads

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686923b2fc9883309384bb1de9c348e5