### PR TITLE
Fix Scripture page to display chapter verses

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -40,6 +40,24 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
   );
   const [verses, setVerses] = React.useState<Verse[]>([]);
 
+  // Initialize default selections so the page shows content immediately
+  React.useEffect(() => {
+    if (!version) {
+      setVersion(bibleVersions[0]?.module);
+      setBook(bibleBooks[0]?.name);
+      setChapter(1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // When the user picks a new version reset book and chapter to defaults
+  React.useEffect(() => {
+    if (version && book === undefined) {
+      setBook(bibleBooks[0]?.name);
+      setChapter(1);
+    }
+  }, [version, book]);
+
   React.useEffect(() => {
     if (version && book && chapter) {
       logger.debug(
@@ -132,6 +150,11 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
           },
         }}
       />
+      {book && chapter && (
+        <h2 style={{ padding: "1rem" }}>
+          {book} {chapter}
+        </h2>
+      )}
       <div
         style={{
           padding: "1rem",

--- a/src/pages/ScripturePage.tsx
+++ b/src/pages/ScripturePage.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import Scriptures from "../components/Scriptures";
+import PageLayoutWrapper from "../components/PageLayoutWrapper";
 import { logger } from "../lib/logger";
 
 export default function ScripturePage() {
   React.useEffect(() => {
     logger.info("Rendering ScripturePage");
   }, []);
-  return <Scriptures />;
+  return (
+    <PageLayoutWrapper>
+      <Scriptures />
+    </PageLayoutWrapper>
+  );
 }


### PR DESCRIPTION
## Summary
- set default Bible version, book, and chapter in Scriptures component
- reset selections when version changes
- show heading with selected book and chapter
- wrap the Scripture page with page layout so it has navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686926f8a6788330966dfc41ade420c1