### PR TITLE
Fix ScripturePage layout

### DIFF
--- a/src/pages/ScripturePage.tsx
+++ b/src/pages/ScripturePage.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 import Scriptures from "../components/Scriptures";
-import PageLayoutWrapper from "../components/PageLayoutWrapper";
+// The Scriptures component already includes the page layout with a navbar.
+// Wrapping it in another layout results in a duplicate navbar, so we
+// render the component directly.
 import { logger } from "../lib/logger";
 
 export default function ScripturePage() {
   React.useEffect(() => {
     logger.info("Rendering ScripturePage");
   }, []);
-  return (
-    <PageLayoutWrapper>
-      <Scriptures />
-    </PageLayoutWrapper>
-  );
+  return <Scriptures />;
 }


### PR DESCRIPTION
## Summary
- remove redundant PageLayoutWrapper on Scripture page to avoid duplicate navbars

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68692b8801b883308082de8229baf109