### PR TITLE
Fix verse display when API returns no data

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -72,9 +72,17 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
           }
           return res.json();
         })
-        .then((data) => {
-          setVerses(data);
+        .then((data: Verse[]) => {
           const found = bibleBooks.find((b) => b.name === book);
+          if (!data.length) {
+            logger.warn(
+              `No verses returned for ${book} chapter ${chapter} from version ${version}`
+            );
+            alert(`No verses found for ${book} chapter ${chapter}`);
+            setVerses([]);
+            return;
+          }
+          setVerses(data);
           if (found) {
             logger.debug(
               `Loaded ${found.name} chapter ${chapter} successfully`


### PR DESCRIPTION
## Summary
- handle the case where the Bible API returns an empty array

## Testing
- `npm test`
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68692f6dbb508330823842e65b5b5b7e