### PR TITLE
Display verses before alert and log verse output

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -9,6 +9,7 @@ import { HTMLElementRefOf } from "@plasmicapp/react-web";
 import { bibleBooks } from "../lib/bibleData";
 import { bibleVersions } from "../lib/bibleVersions";
 import { logger } from "../lib/logger";
+import { flushSync } from "react-dom";
 
 interface Verse {
   verse: number;
@@ -82,7 +83,18 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
             setVerses([]);
             return;
           }
-          setVerses(data);
+          flushSync(() => {
+            setVerses(data);
+          });
+          try {
+            data.forEach((v, idx) => {
+              logger.info(
+                `Displaying verse ${idx + 1}/${data.length}: ${v.text}`
+              );
+            });
+          } catch (err) {
+            logger.error("Failed logging verses", err);
+          }
           if (found) {
             logger.debug(
               `Loaded ${found.name} chapter ${chapter} successfully`


### PR DESCRIPTION
## Summary
- show verses immediately when success dialog appears
- log each verse being displayed

## Testing
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68694119bce4833088ae552e00187ba0