### PR TITLE
Fix verse display within scripture page layout

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -169,27 +169,40 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
             },
           },
         }}
-      />
-      {book && chapter && (
-        <h2 style={{ padding: "1rem" }}>
-          {book} {chapter}
-        </h2>
-      )}
-      <div
-        style={{
-          padding: "1rem",
-          display: "flex",
-          flexDirection: "column",
-          gap: "0.5rem",
+        pageLayout={{
+          props: {
+            children: (
+              <div style={{ padding: "1rem" }}>
+                {book && chapter && (
+                  <h2>
+                    {book} {chapter}
+                  </h2>
+                )}
+                <div
+                  style={{
+                    paddingTop: "1rem",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.5rem",
+                  }}
+                >
+                  {verses.map((v) => (
+                    <div
+                      key={v.verse}
+                      style={{ display: "flex", gap: "0.5rem" }}
+                    >
+                      <div style={{ width: "2rem", textAlign: "right" }}>
+                        {v.verse}
+                      </div>
+                      <div>{v.text}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ),
+          },
         }}
-      >
-        {verses.map((v) => (
-          <div key={v.verse} style={{ display: "flex", gap: "0.5rem" }}>
-            <div style={{ width: "2rem", textAlign: "right" }}>{v.verse}</div>
-            <div>{v.text}</div>
-          </div>
-        ))}
-      </div>
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- render verse text inside the `PageLayout` section so it appears on screen

## Testing
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6869427e1f4c8330849e84cfecb0f09b