### PR TITLE
Use ScriptureNotesGrid slot for verse notes

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -8,7 +8,6 @@ import { bibleBooks } from "../lib/bibleData";
 import { bibleVersions } from "../lib/bibleVersions";
 import { logger } from "../lib/logger";
 import { flushSync } from "react-dom";
-import { VerseNotesSection } from "./VerseNotesSection"; // <-- adjust path if needed
 
 interface Verse {
   verse: number;
@@ -88,8 +87,8 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
         value: chapter,
         onChange: (c) => setChapter(c as number),
       }}
-      // Inject verse display into notesContent slot
-      notesContent={{
+      // Inject verse display into ScriptureNotesGrid slot
+      ScriptureNotesGrid={{
         children: verses.map((v) => (
           <div
             key={v.verse}


### PR DESCRIPTION
## Summary
- remove unused VerseNotesSection import
- display verses with note fields in the ScriptureNotesGrid slot

## Testing
- `npm run build`
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869cd0782588330904f27a6ef0665c6