### PR TITLE
Display verses in ScriptureNotesGrid

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -8,6 +8,7 @@ import { bibleBooks } from "../lib/bibleData";
 import { bibleVersions } from "../lib/bibleVersions";
 import { logger } from "../lib/logger";
 import { flushSync } from "react-dom";
+import ScriptureNotesGrid from "./ScriptureNotesGrid";
 
 interface Verse {
   verse: number;
@@ -90,23 +91,28 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
       // Inject verse display into ScriptureNotesGrid slot
       ScriptureNotesGrid={{
         children: verses.map((v) => (
-          <div
+          <ScriptureNotesGrid
             key={v.verse}
-            style={{
-              borderBottom: "1px solid #eee",
-              padding: "0.5rem 0",
+            scriptureText={{
+              children: (
+                <>
+                  <div style={{ fontWeight: "bold", marginBottom: "0.25rem" }}>
+                    Verse {v.verse}
+                  </div>
+                  <div>{v.text}</div>
+                </>
+              ),
             }}
-          >
-            <div style={{ fontWeight: "bold", marginBottom: "0.25rem" }}>
-              Verse {v.verse}
-            </div>
-            <div>{v.text}</div>
-            <textarea
-              placeholder={`Notes for verse ${v.verse}`}
-              style={{ marginTop: "0.5rem", width: "100%" }}
-              rows={2}
-            />
-          </div>
+            noteText={{
+              children: (
+                <textarea
+                  placeholder={`Notes for verse ${v.verse}`}
+                  style={{ width: "100%" }}
+                  rows={2}
+                />
+              ),
+            }}
+          />
         )),
       }}
       {...props}


### PR DESCRIPTION
## Summary
- import the ScriptureNotesGrid component in `Scriptures.tsx`
- show each verse using its own `ScriptureNotesGrid` pair so scripture text is left and notes are on the right

## Testing
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_686a6351cdc08330989f9791b175cfa4