### PR TITLE
Add notes grid with Supabase integration

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -93,25 +93,10 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
         children: verses.map((v) => (
           <ScriptureNotesGrid
             key={v.verse}
-            scriptureText={{
-              children: (
-                <>
-                  <div style={{ fontWeight: "bold", marginBottom: "0.25rem" }}>
-                    Verse {v.verse}
-                  </div>
-                  <div>{v.text}</div>
-                </>
-              ),
-            }}
-            noteText={{
-              children: (
-                <textarea
-                  placeholder={`Notes for verse ${v.verse}`}
-                  style={{ width: "100%" }}
-                  rows={2}
-                />
-              ),
-            }}
+            book={book!}
+            chapter={chapter!}
+            verse={v.verse}
+            text={v.text}
           />
         )),
       }}


### PR DESCRIPTION
## Summary
- implement `ScriptureNotesGrid` to load and save notes for each verse
- pass book/chapter/verse info from `Scriptures` to `ScriptureNotesGrid`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a68d0a4c883309e38169e4e6b67c2