### PR TITLE
Improve Supabase error logging

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -7,7 +7,7 @@ import { HTMLElementRefOf } from "@plasmicapp/react-web";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../lib/supabaseClient";
 import { useAuth } from "../AuthContext";
-import { logger } from "../lib/logger";
+import { logger, logSupabaseError } from "../lib/logger";
 
 export interface LoginProps extends DefaultLoginProps {}
 
@@ -88,6 +88,7 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
           .single();
 
         if (error) {
+          logSupabaseError('handleVerify fetch profile', error);
           logger.warn('[handleVerify] Profile not found, creating new');
           const { data: newProfile, error: insertError } = await supabase
             .from('UserProfile')
@@ -95,10 +96,10 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
             .select('*')
             .single();
           if (insertError) {
-            logger.error('[handleVerify] Insert error:', insertError);
-          } else {
-            setProfile(newProfile);
-          }
+            logSupabaseError('handleVerify insert', insertError);
+            } else {
+              setProfile(newProfile);
+            }
         } else if (profileData) {
           setProfile(profileData);
         } else {

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -5,7 +5,7 @@ import {
 } from "../plasmic/my_bible_app_next_generation/PlasmicProfile";
 import { supabase } from "../lib/supabaseClient";
 import { useAuth } from "../AuthContext";
-import { logger } from "../lib/logger";
+import { logger, logSupabaseError } from "../lib/logger";
 
 export interface ProfileProps extends DefaultProfileProps {}
 
@@ -35,7 +35,7 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
         .single();
 
       if (error) {
-        logger.error("[fetchProfile]", error);
+        logSupabaseError('fetchProfile', error);
       } else if (data) {
         setProfileId(data.id ?? null);
         setPhone(data.phoneNumber ?? "");
@@ -67,7 +67,7 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
     const { error } = await supabase.from("UserProfile").upsert(profile);
 
     if (error) {
-      logger.error("[handleSave]", error);
+      logSupabaseError('handleSave', error);
       alert("Failed to save profile");
     } else {
       setProfileId(newId);
@@ -89,7 +89,7 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
       .maybeSingle();
 
     if (error) {
-      logger.error("[handleQuery]", error);
+      logSupabaseError('handleQuery', error);
       alert("Failed to fetch profile");
     } else if (data) {
       setProfileId(data.id ?? null);

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -8,7 +8,7 @@ import {
 import { HTMLElementRefOf } from "@plasmicapp/react-web";
 import { supabase } from "../lib/supabaseClient";
 import { useAuth } from "../AuthContext";
-import { logger } from "../lib/logger";
+import { logger, logSupabaseError } from "../lib/logger";
 
 // Your component props start with props for variants and slots you defined
 // in Plasmic, but you can add more here, like event handlers that you can
@@ -58,7 +58,7 @@ function ScriptureNotesGrid_(
         .maybeSingle();
 
       if (error) {
-        logger.error("[ScriptureNotesGrid] Fetch note", error);
+        logSupabaseError('ScriptureNotesGrid fetchNote', error);
       } else if (data) {
         setNoteId(data.id);
         setContent(data.content ?? "");
@@ -93,7 +93,7 @@ function ScriptureNotesGrid_(
       .single();
 
     if (error) {
-      logger.error("[ScriptureNotesGrid] Save note", error);
+      logSupabaseError('ScriptureNotesGrid saveNote', error);
     } else {
       setNoteId(id);
     }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,5 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 function format(level: LogLevel, args: any[]): string {
@@ -12,3 +14,18 @@ export const logger = {
   warn: (...args: any[]) => console.warn(format('warn', args)),
   error: (...args: any[]) => console.error(format('error', args)),
 };
+
+export function logSupabaseError(context: string, error: PostgrestError | null) {
+  if (!error) {
+    return;
+  }
+  const { message, details, hint, code } = error;
+  logger.error(
+    `[Supabase] ${context}: ${message}`,
+    {
+      details,
+      hint,
+      code,
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add `logSupabaseError` helper to report detailed Supabase errors
- log Supabase errors in Profile, ScriptureNotesGrid, and Login components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686afea054948330b7c58e90965c4b61