### PR TITLE
Add book/chapter notes support

### DIFF
--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import { supabase } from "../lib/supabaseClient";
+import { useAuth } from "../AuthContext";
+import { logger, logSupabaseError } from "../lib/logger";
+
+export interface BookChapterNoteProps {
+  book: string;
+  chapter?: number;
+  label: string;
+}
+
+export default function BookChapterNote({ book, chapter, label }: BookChapterNoteProps) {
+  const { profile } = useAuth();
+  const loginId = profile?.phoneNumber;
+  const [noteId, setNoteId] = React.useState<string | null>(null);
+  const [content, setContent] = React.useState<string>("");
+
+  React.useEffect(() => {
+    const fetchNote = async () => {
+      if (!supabase || !loginId) {
+        logger.warn("[BookChapterNote] Supabase or loginId missing");
+        return;
+      }
+      let query = supabase
+        .from("Note")
+        .select("id,content")
+        .eq("loginId", loginId)
+        .eq("book", book)
+        .is("verse", null);
+      if (chapter === undefined) {
+        query = query.is("chapter", null);
+      } else {
+        query = query.eq("chapter", chapter);
+      }
+
+      const { data, error } = await query.maybeSingle();
+
+      if (error) {
+        logSupabaseError('BookChapterNote fetchNote', error);
+      } else if (data) {
+        setNoteId(data.id);
+        setContent(data.content ?? "");
+      } else {
+        setNoteId(null);
+        setContent("");
+      }
+    };
+
+    fetchNote();
+  }, [loginId, book, chapter]);
+
+  const saveNote = async () => {
+    if (!supabase || !loginId) {
+      logger.warn("[BookChapterNote] Cannot save without Supabase or loginId");
+      return;
+    }
+
+    const id = noteId ?? crypto.randomUUID();
+    const { error } = await supabase
+      .from("Note")
+      .upsert({
+        id,
+        loginId,
+        book,
+        chapter: chapter ?? null,
+        verse: null,
+        content,
+        updatedAt: new Date().toISOString(),
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      logSupabaseError('BookChapterNote saveNote', error);
+    } else {
+      setNoteId(id);
+    }
+  };
+
+  return (
+    <div style={{ width: "100%", marginBottom: "1rem" }}>
+      <div style={{ fontWeight: "bold", marginBottom: "0.25rem" }}>{label}</div>
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onBlur={saveNote}
+        rows={3}
+        style={{ width: "100%" }}
+        placeholder={label}
+      />
+    </div>
+  );
+}

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -7,6 +7,7 @@ import {
 } from "../plasmic/my_bible_app_next_generation/PlasmicScriptures";
 import PageLayoutWrapper from "./PageLayoutWrapper";
 import ScriptureNotesGrid from "./ScriptureNotesGrid";
+import BookChapterNote from "./BookChapterNote";
 import { HTMLElementRefOf } from "@plasmicapp/react-web";
 import { bibleBooks } from "../lib/bibleData";
 import { bibleVersions } from "../lib/bibleVersions";
@@ -171,6 +172,14 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
           <h2 style={{ marginTop: "1rem" }}>
             {book} {chapter}
           </h2>
+        )}
+
+        {book && (
+          <BookChapterNote book={book} label="Book Notes" />
+        )}
+
+        {book && chapter && (
+          <BookChapterNote book={book} chapter={chapter} label="Chapter Notes" />
         )}
 
         <div


### PR DESCRIPTION
## Summary
- allow taking notes for a whole book or chapter
- show these notes above the verse notes on the Scripture page

## Testing
- `npm install` in backend
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b0c0e4b408330add1c55c7af51716