### PR TITLE
Add descriptive note summaries

### DIFF
--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -56,6 +56,11 @@ export default function BookChapterNote({ book, chapter, label }: BookChapterNot
     }
 
     const id = noteId ?? crypto.randomUUID();
+    const prefix =
+      chapter === undefined
+        ? `Notes for Book ${book}`
+        : `Notes for Chapter ${book} ${chapter}`;
+
     const { error } = await supabase
       .from("Note")
       .upsert({
@@ -64,7 +69,7 @@ export default function BookChapterNote({ book, chapter, label }: BookChapterNot
         book,
         chapter: chapter ?? null,
         verse: null,
-        content,
+        content: `${prefix}: ${content}`,
         updatedAt: new Date().toISOString(),
       })
       .select("id")

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -78,6 +78,8 @@ function ScriptureNotesGrid_(
     }
 
     const id = noteId ?? crypto.randomUUID();
+    const prefix = `Notes for Scripture ${book} ${chapter}:${verse} - ${text}`;
+
     const { error } = await supabase
       .from("Note")
       .upsert({
@@ -86,7 +88,7 @@ function ScriptureNotesGrid_(
         book,
         chapter,
         verse,
-        content,
+        content: `${prefix}: ${content}`,
         updatedAt: new Date().toISOString(),
       })
       .select("id")


### PR DESCRIPTION
## Summary
- store note summaries referencing the location

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686b0e2f1d74833097951af7486a1edc