### PR TITLE
Add Go example for sqlite + mongo notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,18 @@ npm test
 
 This executes all specs in `backend/test/` and verifies that phone numbers are
 normalized correctly.
+
+## Go Example for SQLite and MongoDB
+
+A small Go program is provided in [`go-example/`](go-example/) for retrieving scriptures from a SQLite database and logging notes stored in MongoDB. Follow these steps to try it out:
+
+1. Ensure Go 1.20+ is installed.
+2. Set the required environment variables as described in [`go-example/README.md`](go-example/README.md). At minimum you must specify `BOOK`, `CHAPTER`, `MONGO_URI`, `MONGO_DB` and `MONGO_NOTES_COLLECTION`.
+3. From the `go-example` directory, run:
+
+```bash
+cd go-example
+go run .
+```
+
+The program logs the verses and notes it retrieves. If nothing is returned, you will see `no verses found` or `no notes found` in the output which helps confirm the queries executed.

--- a/go-example/README.md
+++ b/go-example/README.md
@@ -1,0 +1,35 @@
+# Go Example: Querying Scriptures and Notes
+
+This directory contains a simple Go program that demonstrates how to retrieve Bible verses from a SQLite database and notes from a MongoDB collection. The results are logged to the console.
+
+## Requirements
+
+- Go 1.20 or newer
+- A SQLite database file containing a `verses` table with `book_name`, `chapter_num`, `verse_num` and `verse_text` columns
+- Access to a MongoDB instance containing a `notes` collection
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `SQLITE_DB_PATH` | Path to the SQLite Bible database (defaults to `bible.db` in the current directory) |
+| `BOOK` | Book name to query, e.g. `John` |
+| `CHAPTER` | Chapter number to query |
+| `MONGO_URI` | Connection URI for MongoDB |
+| `MONGO_DB` | Name of the MongoDB database |
+| `MONGO_NOTES_COLLECTION` | Name of the collection containing notes |
+
+## Running the Example
+
+1. Set the required environment variables. At a minimum `BOOK`, `CHAPTER`, `MONGO_URI`, `MONGO_DB` and `MONGO_NOTES_COLLECTION` must be provided. Optionally set `SQLITE_DB_PATH` if your database is not `bible.db`.
+
+2. Run the program:
+
+```bash
+cd go-example
+go run .
+```
+
+3. The program will log the scriptures for the specified book and chapter as well as all notes from the MongoDB collection.
+
+If no results are found, the program will log `no verses found` or `no notes found` so that you can verify the queries executed successfully.

--- a/go-example/main.go
+++ b/go-example/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "context"
+    "database/sql"
+    "fmt"
+    "log"
+    "os"
+
+    _ "github.com/mattn/go-sqlite3"
+    "go.mongodb.org/mongo-driver/mongo"
+    "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+    dbPath := os.Getenv("SQLITE_DB_PATH")
+    if dbPath == "" {
+        dbPath = "bible.db"
+    }
+    book := os.Getenv("BOOK")
+    chapter := os.Getenv("CHAPTER")
+    if book == "" || chapter == "" {
+        log.Println("BOOK and CHAPTER env vars required to query scriptures")
+    }
+    // open SQLite database
+    db, err := sql.Open("sqlite3", dbPath)
+    if err != nil {
+        log.Fatalf("failed to open SQLite db: %v", err)
+    }
+    defer db.Close()
+
+    var verses []string
+    if book != "" && chapter != "" {
+        rows, err := db.Query(`SELECT verse_num, verse_text FROM verses WHERE book_name=? AND chapter_num=? ORDER BY verse_num`, book, chapter)
+        if err != nil {
+            log.Fatalf("query verses: %v", err)
+        }
+        defer rows.Close()
+        for rows.Next() {
+            var num int
+            var text string
+            if err := rows.Scan(&num, &text); err != nil {
+                log.Fatalf("scan verse: %v", err)
+            }
+            verses = append(verses, fmt.Sprintf("%d %s", num, text))
+        }
+        if len(verses) == 0 {
+            log.Println("no verses found")
+        } else {
+            log.Println("scriptures:")
+            for _, v := range verses {
+                log.Println(v)
+            }
+        }
+    }
+
+    mongoURI := os.Getenv("MONGO_URI")
+    mongoDB := os.Getenv("MONGO_DB")
+    notesCollection := os.Getenv("MONGO_NOTES_COLLECTION")
+    if mongoURI == "" || mongoDB == "" || notesCollection == "" {
+        log.Println("MONGO_URI, MONGO_DB and MONGO_NOTES_COLLECTION env vars must be set for notes")
+        return
+    }
+    client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(mongoURI))
+    if err != nil {
+        log.Fatalf("connect mongo: %v", err)
+    }
+    defer client.Disconnect(context.Background())
+
+    coll := client.Database(mongoDB).Collection(notesCollection)
+    cur, err := coll.Find(context.Background(), struct{}{})
+    if err != nil {
+        log.Fatalf("find notes: %v", err)
+    }
+    defer cur.Close(context.Background())
+
+    log.Println("notes:")
+    found := false
+    for cur.Next(context.Background()) {
+        var note struct{ Text string `bson:"text"` }
+        if err := cur.Decode(&note); err != nil {
+            log.Fatalf("decode note: %v", err)
+        }
+        log.Println("-", note.Text)
+        found = true
+    }
+    if !found {
+        log.Println("no notes found")
+    }
+}


### PR DESCRIPTION
## Summary
- create `go-example` directory with Go code to query a SQLite bible database and list notes from MongoDB
- document environment variables and instructions for the Go example
- mention the Go example in the root README

## Testing
- `npm install` in backend
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b0fbdd2a08330923824869e4c9c45