### PR TITLE
Remember login id in profile and show user info

### DIFF
--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -11,7 +11,9 @@ export interface BookChapterNoteProps {
 
 export default function BookChapterNote({ book, chapter, label }: BookChapterNoteProps) {
   const { profile } = useAuth();
-  const loginId = profile?.phoneNumber;
+  const loginId =
+    profile?.phoneNumber ||
+    (typeof window !== "undefined" ? localStorage.getItem("loginId") || undefined : undefined);
   const [noteId, setNoteId] = React.useState<string | null>(null);
   const [content, setContent] = React.useState<string>("");
 

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -10,7 +10,7 @@ import { logger, logSupabaseError } from "../lib/logger";
 export interface ProfileProps extends DefaultProfileProps {}
 
 function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
-  const { profile: authProfile } = useAuth();
+  const { profile: authProfile, setProfile } = useAuth();
   const [phone, setPhone] = React.useState(authProfile?.phoneNumber ?? "");
   const [name, setName] = React.useState("");
   const [email, setEmail] = React.useState("");
@@ -48,6 +48,16 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
     fetchProfile();
   }, [authProfile?.phoneNumber]);
 
+  React.useEffect(() => {
+    if (authProfile?.phoneNumber) {
+      try {
+        localStorage.setItem("loginId", authProfile.phoneNumber);
+      } catch {
+        // ignore storage errors
+      }
+    }
+  }, [authProfile?.phoneNumber]);
+
   const handleSave = async () => {
     if (!supabase) {
       logger.error("[handleSave] Supabase client is not initialized");
@@ -71,6 +81,12 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
       alert("Failed to save profile");
     } else {
       setProfileId(newId);
+      setProfile(profile);
+      try {
+        localStorage.setItem("loginId", phone);
+      } catch {
+        // ignore storage errors
+      }
       alert("Profile saved successfully");
     }
   };
@@ -97,6 +113,12 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
       setName(data.name ?? "");
       setEmail(data.email ?? "");
       setIsEmailVerified(data.emailVerified ? "true" : "false");
+      setProfile(data);
+      try {
+        localStorage.setItem("loginId", data.phoneNumber ?? "");
+      } catch {
+        // ignore storage errors
+      }
     } else {
       alert("No profile found");
     }

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -36,7 +36,9 @@ function ScriptureNotesGrid_(
   ref: HTMLElementRefOf<"div">
 ) {
   const { profile } = useAuth();
-  const loginId = profile?.phoneNumber;
+  const loginId =
+    profile?.phoneNumber ||
+    (typeof window !== "undefined" ? localStorage.getItem("loginId") || undefined : undefined);
   const [noteId, setNoteId] = React.useState<string | null>(null);
   const [content, setContent] = React.useState<string>("");
 

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -13,6 +13,7 @@ import { bibleBooks } from "../lib/bibleData";
 import { bibleVersions } from "../lib/bibleVersions";
 import { logger } from "../lib/logger";
 import { flushSync } from "react-dom";
+import { useAuth } from "../AuthContext";
 
 interface Verse {
   verse: number;
@@ -22,6 +23,7 @@ interface Verse {
 export interface ScripturesProps extends DefaultScripturesProps {}
 
 function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
+  const { profile } = useAuth();
   const [book, setBook] = React.useState<string | undefined>(undefined);
   const [chapter, setChapter] = React.useState<number | undefined>(undefined);
   const [version, setVersion] = React.useState<string | undefined>(undefined);
@@ -110,7 +112,12 @@ function Scriptures_(props: ScripturesProps, ref: HTMLElementRefOf<"div">) {
 
   return (
     <PageLayoutWrapper>
-      <div ref={ref} style={{ padding: "1rem" }}>
+      <div ref={ref} style={{ padding: "1rem", position: "relative" }}>
+        {profile && (
+          <div style={{ position: "absolute", top: 0, left: 0 }}>
+            <strong>{profile.name}</strong> {profile.phoneNumber}
+          </div>
+        )}
         <div
           style={{
             display: "flex",


### PR DESCRIPTION
## Summary
- store profile loginId in localStorage and context when querying/saving the profile
- show profile name and phone in the Scripture page header
- fall back to stored loginId when saving or querying notes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b13b8d9cc8330b968babcd5141083