### PR TITLE
Persist profile information after login

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useState, useEffect } from "react";
 
 export interface AuthContextType {
   isVerified: boolean;
@@ -11,7 +11,35 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isVerified, setIsVerified] = useState(false);
-  const [profile, setProfile] = useState<any>(null);
+  const [profile, setProfile] = useState<any>(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    try {
+      const stored = localStorage.getItem("profile");
+      return stored ? JSON.parse(stored) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    try {
+      if (profile) {
+        localStorage.setItem("profile", JSON.stringify(profile));
+        if (profile.phoneNumber) {
+          localStorage.setItem("loginId", profile.phoneNumber);
+        }
+      } else {
+        localStorage.removeItem("profile");
+      }
+    } catch {
+      // ignore storage errors
+    }
+  }, [profile]);
 
   return (
     <AuthContext.Provider value={{ isVerified, setIsVerified, profile, setProfile }}>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -75,7 +75,14 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
         if (!supabase) {
           logger.error('[handleVerify] Supabase client is not initialized');
           alert('Verification succeeded, but Supabase is not configured.');
-          setProfile({ phoneNumber: phone });
+          const tempProfile = { phoneNumber: phone };
+          setProfile(tempProfile);
+          try {
+            localStorage.setItem('loginId', phone);
+            localStorage.setItem('profile', JSON.stringify(tempProfile));
+          } catch {
+            // ignore storage errors
+          }
           setIsVerified(true);
           navigate('/profile');
           return;
@@ -97,13 +104,32 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
             .single();
           if (insertError) {
             logSupabaseError('handleVerify insert', insertError);
-            } else {
-              setProfile(newProfile);
+          } else if (newProfile) {
+            setProfile(newProfile);
+            try {
+              localStorage.setItem('loginId', newProfile.phoneNumber ?? '');
+              localStorage.setItem('profile', JSON.stringify(newProfile));
+            } catch {
+              // ignore storage errors
             }
+          }
         } else if (profileData) {
           setProfile(profileData);
+          try {
+            localStorage.setItem('loginId', profileData.phoneNumber ?? '');
+            localStorage.setItem('profile', JSON.stringify(profileData));
+          } catch {
+            // ignore storage errors
+          }
         } else {
-          setProfile({ phoneNumber: phone });
+          const tempProfile = { phoneNumber: phone };
+          setProfile(tempProfile);
+          try {
+            localStorage.setItem('loginId', phone);
+            localStorage.setItem('profile', JSON.stringify(tempProfile));
+          } catch {
+            // ignore storage errors
+          }
         }
 
         setIsVerified(true);


### PR DESCRIPTION
## Summary
- persist profile info in localStorage via AuthContext
- store loginId and profile data when verifying login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b15e64ad88330a3234dac579ab680