### PR TITLE
Fetch and store actual note content

### DIFF
--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -58,10 +58,6 @@ export default function BookChapterNote({ book, chapter, label }: BookChapterNot
     }
 
     const id = noteId ?? crypto.randomUUID();
-    const prefix =
-      chapter === undefined
-        ? `Notes for Book ${book}`
-        : `Notes for Chapter ${book} ${chapter}`;
 
     const { error } = await supabase
       .from("Note")
@@ -71,7 +67,7 @@ export default function BookChapterNote({ book, chapter, label }: BookChapterNot
         book,
         chapter: chapter ?? null,
         verse: null,
-        content: `${prefix}: ${content}`,
+        content,
         updatedAt: new Date().toISOString(),
       })
       .select("id")

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -80,7 +80,6 @@ function ScriptureNotesGrid_(
     }
 
     const id = noteId ?? crypto.randomUUID();
-    const prefix = `Notes for Scripture ${book} ${chapter}:${verse} - ${text}`;
 
     const { error } = await supabase
       .from("Note")
@@ -90,7 +89,7 @@ function ScriptureNotesGrid_(
         book,
         chapter,
         verse,
-        content: `${prefix}: ${content}`,
+        content,
         updatedAt: new Date().toISOString(),
       })
       .select("id")


### PR DESCRIPTION
## Summary
- remove fake prefixes when saving scripture and book notes
- keep only the user's real note content

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b18488f7c8330979f3a5025312204