### PR TITLE
Improve note retrieval logging

### DIFF
--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -23,6 +23,11 @@ export default function BookChapterNote({ book, chapter, label }: BookChapterNot
         logger.warn("[BookChapterNote] Supabase or loginId missing");
         return;
       }
+      logger.debug(
+        `[BookChapterNote] Fetching note for ${book} ${
+          chapter !== undefined ? `chapter ${chapter}` : ""
+        }`
+      );
       let query = supabase
         .from("Note")
         .select("id,content")
@@ -40,9 +45,15 @@ export default function BookChapterNote({ book, chapter, label }: BookChapterNot
       if (error) {
         logSupabaseError('BookChapterNote fetchNote', error);
       } else if (data) {
+        logger.debug(
+          `[BookChapterNote] Loaded note ${data.id} with content length ${
+            data.content?.length ?? 0
+          }`
+        );
         setNoteId(data.id);
         setContent(data.content ?? "");
       } else {
+        logger.debug("[BookChapterNote] No note found");
         setNoteId(null);
         setContent("");
       }

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -42,6 +42,10 @@ function ScriptureNotesGrid_(
         return;
       }
 
+      logger.debug(
+        `[ScriptureNotesGrid] Fetching note for ${book} chapter ${chapter} verse ${verse}`
+      );
+
       const { data, error } = await supabase
         .from("Note")
         .select("id,content")
@@ -54,9 +58,15 @@ function ScriptureNotesGrid_(
       if (error) {
         logSupabaseError("ScriptureNotesGrid fetchNote", error);
       } else if (data) {
+        logger.debug(
+          `[ScriptureNotesGrid] Loaded note ${data.id} with content length ${
+            data.content?.length ?? 0
+          }`
+        );
         setNoteId(data.id);
         setContent(data.content ?? "");
       } else {
+        logger.debug("[ScriptureNotesGrid] No note found");
         setNoteId(null);
         setContent(noteContent ?? ""); // ✅ fallback to noteContent if no DB note exists
       }

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -70,6 +70,10 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
         return;
       }
 
+      logger.debug(
+        `[Scriptures] Loading notes for ${book} chapter ${chapter} (loginId=${loginId})`
+      );
+
       try {
         const [bookNoteRes, chapterNoteRes, verseNotesRes] = await Promise.all([
           supabase
@@ -103,6 +107,14 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
         if (bookNoteRes.data) notesArray.push(bookNoteRes.data);
         if (chapterNoteRes.data) notesArray.push(chapterNoteRes.data);
         if (verseNotesRes.data) notesArray.push(...verseNotesRes.data);
+
+        logger.debug(
+          `[Scriptures] Loaded ${notesArray.length} notes (book=${
+            bookNoteRes.data ? 1 : 0
+          }, chapter=${chapterNoteRes.data ? 1 : 0}, verses=${
+            verseNotesRes.data ? verseNotesRes.data.length : 0
+          })`
+        );
 
         setNotes(notesArray);
       } catch (error) {
@@ -198,6 +210,11 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
                 n.chapter === chapter &&
                 n.verse != null &&
                 n.verse === v.verse
+            );
+            logger.debug(
+              `[Scriptures] Displaying verse ${v.verse} with note length ${
+                note?.content?.length ?? 0
+              }`
             );
             return (
               <ScriptureNotesGrid


### PR DESCRIPTION
## Summary
- add debug logs when fetching notes for book or chapter
- log verse note fetch and note lengths
- log notes loading summary and note rendering in Scriptures

## Testing
- `npm run build`
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_686bd9bf1f548330b61e447679c96404