### PR TITLE
Use profile id for note lookup

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -30,8 +30,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     try {
       if (profile) {
         localStorage.setItem("profile", JSON.stringify(profile));
-        if (profile.phoneNumber) {
-          localStorage.setItem("loginId", profile.phoneNumber);
+        if (profile.id) {
+          localStorage.setItem("loginId", profile.id);
         }
       } else {
         localStorage.removeItem("profile");

--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -12,7 +12,7 @@ export interface BookChapterNoteProps {
 export default function BookChapterNote({ book, chapter, label }: BookChapterNoteProps) {
   const { profile } = useAuth();
   const loginId =
-    profile?.phoneNumber ||
+    profile?.id ||
     (typeof window !== "undefined" ? localStorage.getItem("loginId") || undefined : undefined);
   const [noteId, setNoteId] = React.useState<string | null>(null);
   const [content, setContent] = React.useState<string>("");

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -75,10 +75,10 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
         if (!supabase) {
           logger.error('[handleVerify] Supabase client is not initialized');
           alert('Verification succeeded, but Supabase is not configured.');
-          const tempProfile = { phoneNumber: phone };
+          const tempProfile = { id: phone, phoneNumber: phone };
           setProfile(tempProfile);
           try {
-            localStorage.setItem('loginId', phone);
+            localStorage.setItem('loginId', tempProfile.id);
             localStorage.setItem('profile', JSON.stringify(tempProfile));
           } catch {
             // ignore storage errors
@@ -107,7 +107,7 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
           } else if (newProfile) {
             setProfile(newProfile);
             try {
-              localStorage.setItem('loginId', newProfile.phoneNumber ?? '');
+              localStorage.setItem('loginId', newProfile.id ?? '');
               localStorage.setItem('profile', JSON.stringify(newProfile));
             } catch {
               // ignore storage errors
@@ -116,16 +116,16 @@ function Login_(props: LoginProps, ref: HTMLElementRefOf<"div">) {
         } else if (profileData) {
           setProfile(profileData);
           try {
-            localStorage.setItem('loginId', profileData.phoneNumber ?? '');
+            localStorage.setItem('loginId', profileData.id ?? '');
             localStorage.setItem('profile', JSON.stringify(profileData));
           } catch {
             // ignore storage errors
           }
         } else {
-          const tempProfile = { phoneNumber: phone };
+          const tempProfile = { id: phone, phoneNumber: phone };
           setProfile(tempProfile);
           try {
-            localStorage.setItem('loginId', phone);
+            localStorage.setItem('loginId', tempProfile.id);
             localStorage.setItem('profile', JSON.stringify(tempProfile));
           } catch {
             // ignore storage errors

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -49,14 +49,14 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
   }, [authProfile?.phoneNumber]);
 
   React.useEffect(() => {
-    if (authProfile?.phoneNumber) {
+    if (authProfile?.id) {
       try {
-        localStorage.setItem("loginId", authProfile.phoneNumber);
+        localStorage.setItem("loginId", authProfile.id);
       } catch {
         // ignore storage errors
       }
     }
-  }, [authProfile?.phoneNumber]);
+  }, [authProfile?.id]);
 
   const handleSave = async () => {
     if (!supabase) {
@@ -83,7 +83,7 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
       setProfileId(newId);
       setProfile(profile);
       try {
-        localStorage.setItem("loginId", phone);
+        localStorage.setItem("loginId", newId);
       } catch {
         // ignore storage errors
       }
@@ -115,7 +115,7 @@ function Profile_(props: ProfileProps, ref: React.Ref<HTMLDivElement>) {
       setIsEmailVerified(data.emailVerified ? "true" : "false");
       setProfile(data);
       try {
-        localStorage.setItem("loginId", data.phoneNumber ?? "");
+        localStorage.setItem("loginId", data.id ?? "");
       } catch {
         // ignore storage errors
       }

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -26,7 +26,7 @@ function ScriptureNotesGrid_(
 ) {
   const { profile } = useAuth();
   const loginId =
-    profile?.phoneNumber ||
+    profile?.id ||
     (typeof window !== "undefined"
       ? localStorage.getItem("loginId") || undefined
       : undefined);

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -27,7 +27,7 @@ interface Note {
 function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
   const { profile } = useAuth();
   const loginId =
-    profile?.phoneNumber ||
+    profile?.id ||
     (typeof window !== "undefined" ? localStorage.getItem("loginId") || undefined : undefined);
   const userName = profile?.name ?? "";
 
@@ -136,7 +136,7 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
     <PageLayoutWrapper>
       <div ref={ref} style={{ padding: "1rem" }}>
         <div style={{ marginBottom: "1rem" }}>
-          <strong>User:</strong> {userName || "(no name)"} | <strong>Phone:</strong> {loginId}
+          <strong>User:</strong> {userName || "(no name)"} | <strong>ID:</strong> {loginId}
         </div>
 
         <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>


### PR DESCRIPTION
## Summary
- use `profile.id` as loginId instead of phone number
- update login and profile persistence accordingly
- display the user id instead of phone number

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d7af2d7448330b70c75c04c69fff7