### PR TITLE
Fix chapter and verse notes retrieval

### DIFF
--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -40,6 +40,9 @@ export default function BookChapterNote({ book, chapter, label }: BookChapterNot
         query = query.eq("chapter", chapter);
       }
 
+      // If multiple notes exist, grab the most recently updated one
+      query = query.order("updatedAt", { ascending: false }).limit(1);
+
       const { data, error } = await query.maybeSingle();
 
       if (error) {

--- a/src/components/Scriptures.save2.tsx
+++ b/src/components/Scriptures.save2.tsx
@@ -97,6 +97,7 @@ return (
     {...props}
   />
 );
+}
 
 const Scriptures = React.forwardRef(Scriptures_);
 export default Scriptures;

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -83,6 +83,8 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
             .eq("book", book)
             .is("chapter", null)
             .is("verse", null)
+            .order("updatedAt", { ascending: false })
+            .limit(1)
             .maybeSingle(),
 
           supabase
@@ -92,6 +94,8 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
             .eq("book", book)
             .eq("chapter", chapter)
             .is("verse", null)
+            .order("updatedAt", { ascending: false })
+            .limit(1)
             .maybeSingle(),
 
           supabase
@@ -100,13 +104,23 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
             .eq("loginId", loginId)
             .eq("book", book)
             .eq("chapter", chapter)
-            .not("verse", "is", null),
+            .not("verse", "is", null)
+            .order("updatedAt", { ascending: false }),
         ]);
 
         const notesArray: Note[] = [];
         if (bookNoteRes.data) notesArray.push(bookNoteRes.data);
         if (chapterNoteRes.data) notesArray.push(chapterNoteRes.data);
-        if (verseNotesRes.data) notesArray.push(...verseNotesRes.data);
+        if (verseNotesRes.data) {
+          const unique = new Map<number, Note>();
+          for (const vn of verseNotesRes.data) {
+            const key = vn.verse!;
+            if (!unique.has(key)) {
+              unique.set(key, vn);
+            }
+          }
+          notesArray.push(...unique.values());
+        }
 
         logger.debug(
           `[Scriptures] Loaded ${notesArray.length} notes (book=${


### PR DESCRIPTION
## Summary
- select the latest note for book/chapter
- deduplicate verse notes when loading
- close missing brace in Scriptures.save2

## Testing
- `npm install`
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d90afa34c833095cc84f558b7e3d1