### PR TITLE
Add note editing for book, chapter, and verses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
+.next
+dist
 .env
 backend/.env
 

--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -7,9 +7,10 @@ export interface BookChapterNoteProps {
   book: string;
   chapter?: number;
   label: string;
+  onSaved?: () => void;
 }
 
-export default function BookChapterNote({ book, chapter, label }: BookChapterNoteProps) {
+export default function BookChapterNote({ book, chapter, label, onSaved }: BookChapterNoteProps) {
   const { profile } = useAuth();
   const loginId =
     profile?.id ||
@@ -91,6 +92,7 @@ export default function BookChapterNote({ book, chapter, label }: BookChapterNot
       logSupabaseError('BookChapterNote saveNote', error);
     } else {
       setNoteId(id);
+      onSaved?.();
     }
   };
 

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -18,10 +18,11 @@ export interface ScriptureNotesGridProps
   verse: number;
   text: string;
   noteContent?: string;
+  onSave?: (content: string) => void;
 }
 
 function ScriptureNotesGrid_(
-  { book, chapter, verse, text, noteContent, ...rest }: ScriptureNotesGridProps,
+  { book, chapter, verse, text, noteContent, onSave, ...rest }: ScriptureNotesGridProps,
   ref: HTMLElementRefOf<"div">
 ) {
   const { profile } = useAuth();
@@ -33,9 +34,13 @@ function ScriptureNotesGrid_(
 
   const [noteId, setNoteId] = React.useState<string | null>(null);
   const [content, setContent] = React.useState<string>(noteContent ?? "");
+  const [showNote, setShowNote] = React.useState<boolean>(!!noteContent);
 
   React.useEffect(() => {
     setContent(noteContent ?? "");
+    if (noteContent) {
+      setShowNote(true);
+    }
   }, [noteContent]);
 
   const saveNote = async () => {
@@ -66,6 +71,7 @@ function ScriptureNotesGrid_(
       logSupabaseError("ScriptureNotesGrid saveNote", error);
     } else {
       setNoteId(id);
+      onSave?.(content);
     }
   };
 
@@ -84,15 +90,25 @@ function ScriptureNotesGrid_(
       }}
       noteText={{
         children: (
-          <textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            onBlur={saveNote}
-            placeholder={`Notes for verse ${verse}`}
-            rows={2}
-            style={{ width: "100%" }}
-          />
+          showNote ? (
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              onBlur={saveNote}
+              placeholder={`Notes for verse ${verse}`}
+              rows={2}
+              style={{ width: "100%" }}
+            />
+          ) : null
         ),
+      }}
+      addNotesButton={{
+        children: showNote
+          ? "Hide Notes"
+          : content
+          ? "Edit Notes"
+          : "Add Notes",
+        onClick: () => setShowNote(!showNote),
       }}
       {...rest}
     />


### PR DESCRIPTION
## Summary
- add onSaved callback to `BookChapterNote`
- enable note editing button in `ScriptureNotesGrid`
- add book/chapter note buttons and fetchNotes helper in `Scriptures`
- ignore generated `dist` folder

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d96a1dcbc8330a0aef78ff1c9f25a