### PR TITLE
Always show editable notes

### DIFF
--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -17,6 +17,7 @@ export default function BookChapterNote({ book, chapter, label, onSaved }: BookC
     (typeof window !== "undefined" ? localStorage.getItem("loginId") || undefined : undefined);
   const [noteId, setNoteId] = React.useState<string | null>(null);
   const [content, setContent] = React.useState<string>("");
+  const [savedContent, setSavedContent] = React.useState<string>("");
 
   React.useEffect(() => {
     const fetchNote = async () => {
@@ -56,10 +57,12 @@ export default function BookChapterNote({ book, chapter, label, onSaved }: BookC
         );
         setNoteId(data.id);
         setContent(data.content ?? "");
+        setSavedContent(data.content ?? "");
       } else {
         logger.debug("[BookChapterNote] No note found");
         setNoteId(null);
         setContent("");
+        setSavedContent("");
       }
     };
 
@@ -92,6 +95,7 @@ export default function BookChapterNote({ book, chapter, label, onSaved }: BookC
       logSupabaseError('BookChapterNote saveNote', error);
     } else {
       setNoteId(id);
+      setSavedContent(content);
       onSaved?.();
     }
   };
@@ -102,11 +106,21 @@ export default function BookChapterNote({ book, chapter, label, onSaved }: BookC
       <textarea
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        onBlur={saveNote}
         rows={3}
         style={{ width: "100%" }}
         placeholder={label}
       />
+      <button
+        onClick={saveNote}
+        disabled={content === savedContent}
+        style={{
+          marginTop: "0.25rem",
+          backgroundColor: content !== savedContent ? "#69c0ff" : "#f0f0f0",
+          cursor: content !== savedContent ? "pointer" : "default",
+        }}
+      >
+        Update
+      </button>
     </div>
   );
 }

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -34,13 +34,11 @@ function ScriptureNotesGrid_(
 
   const [noteId, setNoteId] = React.useState<string | null>(null);
   const [content, setContent] = React.useState<string>(noteContent ?? "");
-  const [showNote, setShowNote] = React.useState<boolean>(!!noteContent);
+  const [savedContent, setSavedContent] = React.useState<string>(noteContent ?? "");
 
   React.useEffect(() => {
     setContent(noteContent ?? "");
-    if (noteContent) {
-      setShowNote(true);
-    }
+    setSavedContent(noteContent ?? "");
   }, [noteContent]);
 
   const saveNote = async () => {
@@ -71,6 +69,7 @@ function ScriptureNotesGrid_(
       logSupabaseError("ScriptureNotesGrid saveNote", error);
     } else {
       setNoteId(id);
+      setSavedContent(content);
       onSave?.(content);
     }
   };
@@ -90,26 +89,30 @@ function ScriptureNotesGrid_(
       }}
       noteText={{
         children: (
-          showNote ? (
+          <>
             <textarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
-              onBlur={saveNote}
               placeholder={`Notes for verse ${verse}`}
               rows={2}
               style={{ width: "100%" }}
             />
-          ) : null
+            <button
+              onClick={saveNote}
+              disabled={content === savedContent}
+              style={{
+                marginTop: "0.25rem",
+                backgroundColor:
+                  content !== savedContent ? "#69c0ff" : "#f0f0f0",
+                cursor: content !== savedContent ? "pointer" : "default",
+              }}
+            >
+              Update
+            </button>
+          </>
         ),
       }}
-      addNotesButton={{
-        children: showNote
-          ? "Hide Notes"
-          : content
-          ? "Edit Notes"
-          : "Add Notes",
-        onClick: () => setShowNote(!showNote),
-      }}
+      addNotesButton={{ style: { display: "none" } }}
       {...rest}
     />
   );

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -37,8 +37,6 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
   const [version, setVersion] = React.useState<string | undefined>(undefined);
   const [verses, setVerses] = React.useState<Verse[]>([]);
   const [notes, setNotes] = React.useState<Note[]>([]);
-  const [showBookNote, setShowBookNote] = React.useState(false);
-  const [showChapterNote, setShowChapterNote] = React.useState(false);
 
   React.useEffect(() => {
     if (!version) {
@@ -208,35 +206,23 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
         {book && (
           <div style={{ marginTop: "1rem" }}>
             <strong>Book Notes [{book}]:</strong>
-            <div>{notes.find(n => n.book === book && n.chapter == null && n.verse == null)?.content ?? "(none)"}</div>
-            <button onClick={() => setShowBookNote(!showBookNote)} style={{ marginTop: '0.5rem' }}>
-              {showBookNote ? 'Hide' : 'Add'} Book Note
-            </button>
-            {showBookNote && (
-              <BookChapterNote
-                book={book}
-                label={`Notes for ${book}`}
-                onSaved={fetchNotes}
-              />
-            )}
+            <BookChapterNote
+              book={book}
+              label={`Notes for ${book}`}
+              onSaved={fetchNotes}
+            />
           </div>
         )}
 
         {book && chapter && (
           <div style={{ marginTop: "1rem" }}>
             <strong>Chapter Notes [{chapter}]:</strong>
-            <div>{notes.find(n => n.book === book && n.chapter === chapter && n.verse == null)?.content ?? "(none)"}</div>
-            <button onClick={() => setShowChapterNote(!showChapterNote)} style={{ marginTop: '0.5rem' }}>
-              {showChapterNote ? 'Hide' : 'Add'} Chapter Note
-            </button>
-            {showChapterNote && (
-              <BookChapterNote
-                book={book}
-                chapter={chapter}
-                label={`Notes for ${book} ${chapter}`}
-                onSaved={fetchNotes}
-              />
-            )}
+            <BookChapterNote
+              book={book}
+              chapter={chapter}
+              label={`Notes for ${book} ${chapter}`}
+              onSaved={fetchNotes}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- show note editors for book, chapter, and verses at all times
- enable update buttons when content has changed
- hide old add/hide notes buttons

## Testing
- `npm run build`
- `npm test` in backend


------
https://chatgpt.com/codex/tasks/task_e_686d9dcb91bc83309a4a24df29ebad9d