### PR TITLE
Ensure empty note field when no notes

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -247,7 +247,7 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
                 chapter={chapter!}
                 verse={v.verse}
                 text={v.text}
-                noteContent={note?.content}
+                noteContent={note?.content || ""}
                 onSave={() => fetchNotes()}
               />
             );


### PR DESCRIPTION
## Summary
- default verse note content to empty string when none is loaded

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da6a1ec5c8330b53a10edc9c5bd04