### PR TITLE
Remove placeholders from empty notes

### DIFF
--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -108,7 +108,7 @@ export default function BookChapterNote({ book, chapter, label, onSaved }: BookC
         onChange={(e) => setContent(e.target.value)}
         rows={3}
         style={{ width: "100%" }}
-        placeholder={label}
+        placeholder={content ? undefined : ""}
       />
       <button
         onClick={saveNote}

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -93,7 +93,7 @@ function ScriptureNotesGrid_(
             <textarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
-              placeholder={`Notes for verse ${verse}`}
+              placeholder={content ? undefined : ""}
               rows={2}
               style={{ width: "100%" }}
             />


### PR DESCRIPTION
## Summary
- remove placeholder text when no verse note exists
- remove placeholder text when no book/chapter note exists

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686db3e22d608330906cd3e1d49482c9