### PR TITLE
Fix note reload when changing version

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -138,7 +138,7 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
 
   React.useEffect(() => {
     fetchNotes();
-  }, [fetchNotes]);
+  }, [fetchNotes, version]);
 
   const versions = bibleVersions.map((v) => ({ value: v.module, label: v.shortname || v.name }));
   const bookOptions = bibleBooks.map((b) => ({ value: b.name, label: b.name }));
@@ -161,8 +161,6 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
               value={version}
               onChange={(e) => {
                 setVersion(e.target.value);
-                setBook(undefined);
-                setChapter(undefined);
               }}
             >
               {versions.map((v) => (


### PR DESCRIPTION
## Summary
- reload notes when changing Bible version
- keep the selected book and chapter when the version changes

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686db76d3b7c83309a23c2d5a7d49fdb