### PR TITLE
Enable auto-resizing textareas for notes

### DIFF
--- a/src/components/AutoSizeTextarea.tsx
+++ b/src/components/AutoSizeTextarea.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+export interface AutoSizeTextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const AutoSizeTextarea = React.forwardRef<HTMLTextAreaElement, AutoSizeTextareaProps>(
+  function AutoSizeTextarea({ style, onChange, onInput, ...rest }, ref) {
+    const innerRef = React.useRef<HTMLTextAreaElement | null>(null);
+    const mergedRef = React.useCallback((node: HTMLTextAreaElement | null) => {
+      innerRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLTextAreaElement | null>).current = node;
+      }
+    }, [ref]);
+
+    const resize = React.useCallback(() => {
+      const el = innerRef.current;
+      if (el) {
+        el.style.height = "auto";
+        el.style.height = el.scrollHeight + "px";
+      }
+    }, []);
+
+    React.useLayoutEffect(() => {
+      resize();
+    }, [rest.value, resize]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      resize();
+      onChange?.(e);
+    };
+
+    const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+      resize();
+      onInput?.(e);
+    };
+
+    return (
+      <textarea
+        {...rest}
+        ref={mergedRef}
+        onChange={handleChange}
+        onInput={handleInput}
+        style={{ overflow: "hidden", resize: "none", ...style }}
+      />
+    );
+  }
+);
+
+export default AutoSizeTextarea;

--- a/src/components/BookChapterNote.tsx
+++ b/src/components/BookChapterNote.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { supabase } from "../lib/supabaseClient";
 import { useAuth } from "../AuthContext";
 import { logger, logSupabaseError } from "../lib/logger";
+import AutoSizeTextarea from "./AutoSizeTextarea";
 
 export interface BookChapterNoteProps {
   book: string;
@@ -103,10 +104,9 @@ export default function BookChapterNote({ book, chapter, label, onSaved }: BookC
   return (
     <div style={{ width: "100%", marginBottom: "1rem" }}>
       <div style={{ fontWeight: "bold", marginBottom: "0.25rem" }}>{label}</div>
-      <textarea
+      <AutoSizeTextarea
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        rows={3}
         style={{ width: "100%" }}
         placeholder={content ? undefined : ""}
       />

--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -9,6 +9,7 @@ import { HTMLElementRefOf } from "@plasmicapp/react-web";
 import { supabase } from "../lib/supabaseClient";
 import { useAuth } from "../AuthContext";
 import { logger, logSupabaseError } from "../lib/logger";
+import AutoSizeTextarea from "./AutoSizeTextarea";
 
 // Extend props with noteContent to avoid DOM warning
 export interface ScriptureNotesGridProps
@@ -90,11 +91,10 @@ function ScriptureNotesGrid_(
       noteText={{
         children: (
           <>
-            <textarea
+            <AutoSizeTextarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
               placeholder={content ? undefined : ""}
-              rows={2}
               style={{ width: "100%" }}
             />
             <button


### PR DESCRIPTION
## Summary
- add `AutoSizeTextarea` helper component
- use autosizing textareas in `BookChapterNote` and `ScriptureNotesGrid`

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686db8c55fd883308a4cf44712ed8f64