### PR TITLE
Add API.Bible NIV integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ This project contains a Vite based React frontend and a simple Express backend.
    - **Supabase**: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`
    - **Plasmic**: `PLASMIC_PROJECT_ID`, `PLASMIC_PUBLIC_TOKEN`
 
+The backend exposes a proxy route for API.Bible requests at
+`/api/api-bible/:bibleId`. Query it with `book`, `chapter` and optional `verse`
+to retrieve HTML passages. Example:
+`/api/api-bible/de4e12af7f28f599-01?book=Genesis&chapter=1&verse=1`.
+
 ## Running the Project
 
 Start the Vite dev server:

--- a/backend/index.js
+++ b/backend/index.js
@@ -51,6 +51,14 @@ try {
   logger.error("Failed to load ./routes/bibles.js", err.message);
 }
 
+try {
+  const apiBibleRoute = require(path.join(__dirname, "routes", "api-bible"));
+  app.use("/api/api-bible", apiBibleRoute);
+  logger.info("Loaded /api/api-bible");
+} catch (err) {
+  logger.error("Failed to load ./routes/api-bible.js", err.message);
+}
+
 // Start server
 app.listen(port, () => {
   logger.info(`Server listening on port ${port}`);

--- a/backend/routes/api-bible.js
+++ b/backend/routes/api-bible.js
@@ -1,0 +1,37 @@
+const express = require("express");
+const router = express.Router();
+const logger = require("../utils/logger");
+
+const BIBLE_API_KEY = process.env.BIBLE_API_KEY;
+const DEFAULT_BIBLE_ID = "de4e12af7f28f599-01";
+
+router.get("/:bibleId?", async (req, res) => {
+  if (!BIBLE_API_KEY) {
+    return res.status(500).json({ error: "BIBLE_API_KEY not configured" });
+  }
+  const { book, chapter, verse } = req.query;
+  if (!book || !chapter) {
+    return res.status(400).json({ error: "book and chapter required" });
+  }
+  const bibleId = req.params.bibleId || DEFAULT_BIBLE_ID;
+  const reference = verse ? `${book} ${chapter}:${verse}` : `${book} ${chapter}`;
+  const url = `https://api.scripture.api.bible/v1/bibles/${bibleId}/passages?content-type=html&reference=${encodeURIComponent(reference)}`;
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "api-key": BIBLE_API_KEY,
+      },
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      return res.status(response.status).json(data);
+    }
+    res.json(data);
+  } catch (err) {
+    logger.error("[api-bible] fetch failed", err);
+    res.status(500).json({ error: "failed to fetch" });
+  }
+});
+
+module.exports = router;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import LoginPage from "./pages/LoginPage";
 import ProfilePage from "./pages/ProfilePage";
 import ScripturePage from "./pages/ScripturePage";
 import HomePage from "./pages/HomePage";
+import ApiBiblePage from "./pages/ApiBiblePage";
 import { logger } from "./lib/logger";
 
 function App() {
@@ -20,6 +21,7 @@ function App() {
       <Route path="login" element={<LoginPage />} />
       <Route path="profile" element={<ProfilePage />} />
       <Route path="scriptures" element={<ScripturePage />} />
+      <Route path="passage" element={<ApiBiblePage />} />
     </Routes>
   );
 }

--- a/src/components/ApiBiblePassage.tsx
+++ b/src/components/ApiBiblePassage.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { logger } from "../lib/logger";
+
+interface ApiBiblePassageProps {
+  book: string;
+  chapter: number;
+  verse?: number;
+}
+
+export default function ApiBiblePassage({ book, chapter, verse }: ApiBiblePassageProps) {
+  const [html, setHtml] = React.useState<string>("");
+
+  React.useEffect(() => {
+    const params = new URLSearchParams({ book, chapter: String(chapter) });
+    if (verse !== undefined) params.append("verse", String(verse));
+    fetch(`/api/api-bible/de4e12af7f28f599-01?${params.toString()}`)
+      .then((res) => res.json())
+      .then((data) => {
+        logger.debug("[ApiBiblePassage] fetched", data);
+        setHtml(data.data?.content || "");
+      })
+      .catch((err) => {
+        logger.error("[ApiBiblePassage] fetch error", err);
+      });
+  }, [book, chapter, verse]);
+
+  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/src/components/PageLayoutWrapper.tsx
+++ b/src/components/PageLayoutWrapper.tsx
@@ -13,7 +13,8 @@ export default function PageLayoutWrapper({ children }: { children: React.ReactN
             <Link to="/" style={{ marginRight: "1rem" }}>Home</Link>
             <Link to="/login" style={{ marginRight: "1rem" }}>Login</Link>
             <Link to="/profile" style={{ marginRight: "1rem" }}>Profile</Link>
-            <Link to="/scriptures">Scriptures</Link>
+            <Link to="/scriptures" style={{ marginRight: "1rem" }}>Scriptures</Link>
+            <Link to="/passage">API.Bible Demo</Link>
           </nav>
         ),
       }}

--- a/src/lib/bibleVersions.ts
+++ b/src/lib/bibleVersions.ts
@@ -15,4 +15,9 @@ export const bibleVersions: BibleVersion[] = [
   { module: "net", shortname: "NET", name: "NET Bible\u00ae" },
   { module: "tyndale", shortname: "Tyndale", name: "Tyndale Bible" },
   { module: "web", shortname: "WEB", name: "World English Bible" },
+  {
+    module: "niv_api",
+    shortname: "NIV (API)",
+    name: "New International Version via API.Bible",
+  },
 ];

--- a/src/pages/ApiBiblePage.tsx
+++ b/src/pages/ApiBiblePage.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import PageLayoutWrapper from "../components/PageLayoutWrapper";
+import ApiBiblePassage from "../components/ApiBiblePassage";
+
+export default function ApiBiblePage() {
+  return (
+    <PageLayoutWrapper>
+      <h2>Genesis 1:1 from API.Bible (NIV)</h2>
+      <ApiBiblePassage book="Genesis" chapter={1} verse={1} />
+    </PageLayoutWrapper>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -22,3 +22,20 @@ export async function getScripture(
 
   return data as Verse[];
 }
+
+export async function getPassageHtml(
+  book: string,
+  chapter: number,
+  verse?: number,
+  bibleId = "de4e12af7f28f599-01"
+): Promise<string> {
+  const params = new URLSearchParams({ book, chapter: String(chapter) });
+  if (verse !== undefined) params.append("verse", String(verse));
+  const res = await fetch(`/api/api-bible/${bibleId}?${params.toString()}`);
+
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error || "Failed to fetch passage");
+  }
+  return data.data?.content || "";
+}


### PR DESCRIPTION
## Summary
- proxy API.Bible NIV passages via `/api/api-bible`
- expose the new route in backend server
- allow selecting NIV (API) as a Bible version
- add `ApiBiblePage` and `ApiBiblePassage` component
- update navigation and API helpers
- document API.Bible route

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686dc04058f48330bd2da745daf7fa1e