### PR TITLE
Improve scripture fetch error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The backend exposes a proxy route for API.Bible requests at
 to retrieve HTML passages. Example:
 `/api/api-bible/de4e12af7f28f599-01?book=Genesis&chapter=1&verse=1`.
 
+The included "NIV (API)" bible version relies on this route. Because NIV text
+is not bundled in the repository, a valid `BIBLE_API_KEY` and outbound network
+access are required to load this translation at runtime.
+
 ## Running the Project
 
 Start the Vite dev server:

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -50,8 +50,19 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
     if (version && book && chapter) {
       logger.debug(`Fetching verses for ${book} chapter ${chapter}`);
       fetch(`/api/bibles/${version}?book=${encodeURIComponent(book)}&chapter=${chapter}`)
-        .then((res) => res.json())
-        .then((data: Verse[]) => {
+        .then(async (res) => {
+          if (!res.ok) {
+            logger.error(`Error fetching verses: ${res.status}`);
+            return [];
+          }
+          const data = await res.json();
+          if (!Array.isArray(data)) {
+            logger.error("Scripture response is not an array", data);
+            return [];
+          }
+          return data as Verse[];
+        })
+        .then((data) => {
           flushSync(() => {
             setVerses(data);
           });


### PR DESCRIPTION
## Summary
- guard against invalid scripture responses to avoid runtime crashes
- document the NIV API requirement for network access and an API key

## Testing
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_686dc3ce15208330a2ea5684af934e2e