### PR TITLE
Handle NIV API bible verses

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -8,6 +8,7 @@ import { bibleBooks } from "../lib/bibleData";
 import { bibleVersions } from "../lib/bibleVersions";
 import { logger } from "../lib/logger";
 import { flushSync } from "react-dom";
+import { getScripture } from "../services/api";
 import { useAuth } from "../AuthContext";
 import { supabase } from "../lib/supabaseClient";
 
@@ -49,19 +50,7 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
   React.useEffect(() => {
     if (version && book && chapter) {
       logger.debug(`Fetching verses for ${book} chapter ${chapter}`);
-      fetch(`/api/bibles/${version}?book=${encodeURIComponent(book)}&chapter=${chapter}`)
-        .then(async (res) => {
-          if (!res.ok) {
-            logger.error(`Error fetching verses: ${res.status}`);
-            return [];
-          }
-          const data = await res.json();
-          if (!Array.isArray(data)) {
-            logger.error("Scripture response is not an array", data);
-            return [];
-          }
-          return data as Verse[];
-        })
+      getScripture(version, book, chapter)
         .then((data) => {
           flushSync(() => {
             setVerses(data);


### PR DESCRIPTION
## Summary
- fetch NIV scripture via API.Bible when the NIV (API) version is selected
- parse API.Bible HTML to verse objects
- use `getScripture()` helper in Scriptures component

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc5c35050833084dbd02f0e61f937