### PR TITLE
Fix server startup when Twilio vars missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ npm start
 ```
 The backend listens on the port specified in `backend/.env` (default `5000`).
 
-The backend now validates that `TWILIO_SID`, `TWILIO_AUTH_TOKEN` and
-`TWILIO_VERIFY` are set before it loads any routes. If any of these
-variables are missing, the server logs an error and exits immediately so
-configuration issues are caught right away.
+The backend checks for `TWILIO_SID`, `TWILIO_AUTH_TOKEN` and `TWILIO_VERIFY`
+at startup. Missing variables are logged as a warning, but the server still
+starts so non-Twilio features remain usable. Individual routes that depend on
+Twilio verify their required configuration and return an error if needed.
 
 
 ## Running Backend Tests

--- a/backend/index.js
+++ b/backend/index.js
@@ -8,7 +8,10 @@ const logger = require("./utils/logger");
 const app = express();
 const port = process.env.PORT || 5000;
 
-// Verify critical Twilio environment variables before loading routes
+// Warn if Twilio environment variables are missing, but continue to start.
+// Individual routes already check for required variables and return
+// appropriate errors so the server can still function for non-Twilio
+// features like Bible retrieval even when these are absent.
 const requiredTwilioVars = [
   "TWILIO_SID",
   "TWILIO_AUTH_TOKEN",
@@ -16,10 +19,9 @@ const requiredTwilioVars = [
 ];
 const missingTwilioVars = requiredTwilioVars.filter((v) => !process.env[v]);
 if (missingTwilioVars.length) {
-  logger.error(
-    `[server] Missing environment variables: ${missingTwilioVars.join(", ")}`
+  logger.warn(
+    `[server] Missing Twilio environment variables: ${missingTwilioVars.join(", ")}`
   );
-  process.exit(1);
 }
 
 // Middleware


### PR DESCRIPTION
## Summary
- keep backend running even if Twilio vars are not set
- update README to describe warning behaviour

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687051c6dd1083308654e54eee5b9e3c