### PR TITLE
Add console logs for API Bible requests

### DIFF
--- a/backend/routes/api-bible.js
+++ b/backend/routes/api-bible.js
@@ -13,12 +13,19 @@ async function getPassage(req, res) {
     return res.status(500).json({ error: "BIBLE_API_KEY not configured" });
   }
   const { book, chapter, verse } = req.query;
+  logger.info("[api-bible] incoming", {
+    book,
+    chapter,
+    verse,
+    params: req.params,
+  });
   if (!book || !chapter) {
     return res.status(400).json({ error: "book and chapter required" });
   }
   const bibleId = req.params.bibleId || DEFAULT_BIBLE_ID;
   const reference = verse ? `${book} ${chapter}:${verse}` : `${book} ${chapter}`;
   const url = `https://api.scripture.api.bible/v1/bibles/${bibleId}/passages?content-type=html&reference=${encodeURIComponent(reference)}`;
+  logger.debug("[api-bible] url", url);
 
   try {
     const response = await fetch(url, {
@@ -26,8 +33,10 @@ async function getPassage(req, res) {
         "api-key": BIBLE_API_KEY,
       },
     });
+    logger.info("[api-bible] response", response.status);
     const data = await response.json();
     if (!response.ok) {
+      logger.warn("[api-bible] non-ok", data);
       return res.status(response.status).json(data);
     }
     res.json(data);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,6 +5,8 @@ export type Verse = {
   text: string;
 };
 
+import { logger } from "../lib/logger";
+
 export async function getScripture(
   version: string,
   book: string,
@@ -35,7 +37,9 @@ export async function getPassageHtml(
 ): Promise<string> {
   const params = new URLSearchParams({ book, chapter: String(chapter) });
   if (verse !== undefined) params.append("verse", String(verse));
-  const res = await fetch(`/api/api-bible/${bibleId}?${params.toString()}`);
+  const url = `/api/api-bible/${bibleId}?${params.toString()}`;
+  logger.info("[api] fetch", url);
+  const res = await fetch(url);
 
   const data = await res.json();
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- log incoming parameters and fetch URLs in the `/api/api-bible` backend route
- log requested URL in `getPassageHtml`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716c9176a083309b1c0cd8d669b861