### PR TITLE
Improve logging for Bible API errors

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -24,6 +24,10 @@ if (missingTwilioVars.length) {
   );
 }
 
+if (!process.env.BIBLE_API_KEY) {
+  logger.warn('[server] BIBLE_API_KEY not configured - NIV API requests will fail');
+}
+
 // Middleware
 app.use(cors());
 app.use(express.json());

--- a/backend/routes/api-bible.js
+++ b/backend/routes/api-bible.js
@@ -46,6 +46,7 @@ async function getPassage(req, res) {
     res.json(data);
   } catch (err) {
     logger.error("[api-bible] fetch failed", err);
+    logger.error("[api-bible] error message", err instanceof Error ? err.message : err);
     res.status(500).json({ error: "failed to fetch" });
   }
 }

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -1,6 +1,13 @@
+function stringify(arg) {
+  if (arg instanceof Error) {
+    return arg.stack || arg.message;
+  }
+  return typeof arg === 'string' ? arg : JSON.stringify(arg);
+}
+
 function format(level, args) {
   const time = new Date().toISOString();
-  const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  const msg = args.map(stringify).join(' ');
   return `[${time}] [${level.toUpperCase()}] ${msg}`;
 }
 

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -58,6 +58,7 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
         })
         .catch((err) => {
           logger.error("Error fetching verses", err);
+          logger.error("Error message", err instanceof Error ? err.message : err);
           setVerses([]);
         });
     }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,9 +2,16 @@ import type { PostgrestError } from '@supabase/supabase-js';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+function stringify(arg: any): string {
+  if (arg instanceof Error) {
+    return arg.stack || arg.message;
+  }
+  return typeof arg === 'string' ? arg : JSON.stringify(arg);
+}
+
 function format(level: LogLevel, args: any[]): string {
   const time = new Date().toISOString();
-  const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  const msg = args.map((a) => stringify(a)).join(' ');
   return `[${time}] [${level.toUpperCase()}] ${msg}`;
 }
 


### PR DESCRIPTION
## Summary
- improve front-end and back-end loggers to show Error messages
- log explicit error messages when fetching NIV API passages fails
- warn at server startup if `BIBLE_API_KEY` is not configured

## Testing
- `npm install --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6871b71a960c833088d78196facdeca2