### PR TITLE
Add formatted scripture support with notes

### DIFF
--- a/src/components/ScriptureNotesGrid.tsx
+++ b/src/components/ScriptureNotesGrid.tsx
@@ -18,12 +18,15 @@ export interface ScriptureNotesGridProps
   chapter: number;
   verse: number;
   text: string;
+  formattedText?: React.ReactNode;
+  strongs?: string[];
+  metaNotes?: string[];
   noteContent?: string;
   onSave?: (content: string) => void;
 }
 
 function ScriptureNotesGrid_(
-  { book, chapter, verse, text, noteContent, onSave, ...rest }: ScriptureNotesGridProps,
+  { book, chapter, verse, text, formattedText, strongs, metaNotes, noteContent, onSave, ...rest }: ScriptureNotesGridProps,
   ref: HTMLElementRefOf<"div">
 ) {
   const { profile } = useAuth();
@@ -84,13 +87,25 @@ function ScriptureNotesGrid_(
             <div style={{ fontWeight: "bold", marginBottom: "0.25rem" }}>
               Verse {verse}
             </div>
-            <div>{text}</div>
+            <div>
+              {formattedText ? formattedText : text}
+            </div>
           </>
         ),
       }}
       noteText={{
         children: (
           <>
+            {(strongs && strongs.length > 0) || (metaNotes && metaNotes.length > 0) ? (
+              <div style={{ fontSize: "0.875rem", marginBottom: "0.25rem" }}>
+                {strongs && strongs.length > 0 && (
+                  <div>Strong's: {strongs.join(", ")}</div>
+                )}
+                {metaNotes && metaNotes.map((n, i) => (
+                  <div key={i}>{n}</div>
+                ))}
+              </div>
+            ) : null}
             <AutoSizeTextarea
               value={content}
               onChange={(e) => setContent(e.target.value)}

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -15,6 +15,11 @@ import { supabase } from "../lib/supabaseClient";
 interface Verse {
   verse: number;
   text: string;
+  red?: boolean;
+  italic?: boolean;
+  paragraph?: boolean;
+  strongs?: string[];
+  notes?: string[];
 }
 
 interface Note {
@@ -239,6 +244,14 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
                 note?.content?.length ?? 0
               }`
             );
+            const formatted = (
+              <>
+                {v.paragraph && <br />}
+                <span className={v.red ? "text-red-600" : undefined}>
+                  {v.italic ? <em>{v.text}</em> : v.text}
+                </span>
+              </>
+            );
             return (
               <ScriptureNotesGrid
                 key={v.verse}
@@ -246,6 +259,9 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
                 chapter={chapter!}
                 verse={v.verse}
                 text={v.text}
+                formattedText={formatted}
+                strongs={v.strongs}
+                metaNotes={v.notes}
                 noteContent={note?.content || ""}
                 onSave={() => fetchNotes()}
               />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,6 +3,11 @@ export type Verse = {
   chapter: number;
   verse: number;
   text: string;
+  red?: boolean;
+  italic?: boolean;
+  paragraph?: boolean;
+  strongs?: string[];
+  notes?: string[];
 };
 
 import { logger } from "../lib/logger";


### PR DESCRIPTION
## Summary
- enrich Verse interface to include formatting info and metadata
- display red letters, italics, paragraphs via `formattedText`
- show Strong's references and metadata notes in note section
- adjust ScriptureNotesGrid to render new props

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68739bc0086883308cabe7ccd03e880e