### PR TITLE
Fix bible version caching

### DIFF
--- a/backend/routes/bibles.js
+++ b/backend/routes/bibles.js
@@ -5,22 +5,24 @@ const path = require("path");
 const logger = require("../utils/logger");
 
 const biblesDir = path.join(__dirname, "..", "bibles");
-let versionsCache = null;
+
+// The list of available bible versions is small, so we load the metadata on
+// each request instead of caching it. This allows changes to the underlying
+// JSON files (like net.json) to be picked up without restarting the server.
 
 function loadVersions() {
-  if (versionsCache) return versionsCache;
   try {
     const files = fs
       .readdirSync(biblesDir)
       .filter((f) => f.endsWith(".json"));
-    versionsCache = files.map((file) => {
+    const versions = files.map((file) => {
       const data = JSON.parse(
         fs.readFileSync(path.join(biblesDir, file), "utf8")
       );
       const { name, shortname, module } = data.metadata || {};
       return { name, shortname, module };
     });
-    return versionsCache;
+    return versions;
   } catch (err) {
     logger.error("[bibles] Failed to read versions", err);
     throw err;


### PR DESCRIPTION
## Summary
- reload bible version metadata on each request so updated JSON files are reflected without restart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873d0457d688330891c1cbce53f9927