### PR TITLE
Add debug logs for verse data

### DIFF
--- a/backend/routes/bibles.js
+++ b/backend/routes/bibles.js
@@ -54,6 +54,17 @@ router.get("/:version", (req, res) => {
     const verses = (data.verses || []).filter(
       (v) => v.book_name === book && v.chapter === chapNum
     );
+    if (process.env.NODE_ENV !== "test") {
+      const sample = verses[0];
+      logger.debug(
+        `[bibles] Loaded ${verses.length} verses from ${version}.json ` +
+          `(red_letter=${data.metadata?.red_letter}, italics=${data.metadata?.italics}, ` +
+          `notes field in sample=${sample?.notes ? "present" : "none"})`
+      );
+      if (sample) {
+        logger.debug("[bibles] Sample verse", sample);
+      }
+    }
     res.json(verses);
   } catch (err) {
     logger.error("[bibles] Error reading", err);


### PR DESCRIPTION
## Summary
- log metadata info when serving bible verses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873d924ff0883309bc343ccaa8fd271