### PR TITLE
Add verse meta logging

### DIFF
--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -240,9 +240,10 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
                 n.verse === v.verse
             );
             logger.debug(
-              `[Scriptures] Displaying verse ${v.verse} with note length ${
-                note?.content?.length ?? 0
-              }`
+              `[Scriptures] Displaying verse ${v.verse} ` +
+                `(metaNotes=${v.notes ? v.notes.length : 0}, ` +
+                `red=${v.red ? 1 : 0}, ` +
+                `note length=${note?.content?.length ?? 0})`
             );
             const formatted = (
               <>


### PR DESCRIPTION
## Summary
- log meta note count and red letter indicator when rendering verses

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873de885f4883308680dee636bbe845