### PR TITLE
Support formatted NET verses

### DIFF
--- a/src/components/Scriptures.save.tsx
+++ b/src/components/Scriptures.save.tsx
@@ -16,6 +16,7 @@ import { flushSync } from "react-dom";
 interface Verse {
   verse: number;
   text: string;
+  html?: string;
 }
 
 // Your component props start with props for variants and slots you defined

--- a/src/components/Scriptures.save2.tsx
+++ b/src/components/Scriptures.save2.tsx
@@ -12,6 +12,7 @@ import { flushSync } from "react-dom";
 interface Verse {
   verse: number;
   text: string;
+  html?: string;
 }
 
 export interface ScripturesProps extends DefaultScripturesProps {}

--- a/src/components/Scriptures.tsx
+++ b/src/components/Scriptures.tsx
@@ -15,6 +15,8 @@ import { supabase } from "../lib/supabaseClient";
 interface Verse {
   verse: number;
   text: string;
+  /** Optional HTML string for formatted text */
+  html?: string;
   red?: boolean;
   italic?: boolean;
   paragraph?: boolean;
@@ -245,12 +247,20 @@ function Scriptures_(props: {}, ref: HTMLElementRefOf<"div">) {
                 `red=${v.red ? 1 : 0}, ` +
                 `note length=${note?.content?.length ?? 0})`
             );
+            const verseContent = v.html ? (
+              <span
+                className={v.red ? "text-red-600" : undefined}
+                dangerouslySetInnerHTML={{ __html: v.html }}
+              />
+            ) : (
+              <span className={v.red ? "text-red-600" : undefined}>
+                {v.italic ? <em>{v.text}</em> : v.text}
+              </span>
+            );
             const formatted = (
               <>
-                {v.paragraph && <br />}
-                <span className={v.red ? "text-red-600" : undefined}>
-                  {v.italic ? <em>{v.text}</em> : v.text}
-                </span>
+                {v.paragraph && <span>¶ </span>}
+                {verseContent}
               </>
             );
             return (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,6 +3,8 @@ export type Verse = {
   chapter: number;
   verse: number;
   text: string;
+  /** Raw HTML string with formatting like italics or red lettering. */
+  html?: string;
   red?: boolean;
   italic?: boolean;
   paragraph?: boolean;


### PR DESCRIPTION
## Summary
- allow html formatting in Verse type
- show formatted paragraphs, italics and red letters
- keep placeholder types updated

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874143ce4788330b3f39f22d486d6a3