### PR TITLE
Fix metadata parsing for verse formatting

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -33,7 +33,22 @@ export async function getScripture(
 
   const data = await res.json();
 
-  return data as Verse[];
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.map((v: any, idx: number) => ({
+    book,
+    chapter,
+    verse: v.verse ?? idx + 1,
+    text: v.text ?? "",
+    html: v.html ?? undefined,
+    red: v.red ?? false,
+    italic: v.italic ?? false,
+    paragraph: v.paragraph ?? false,
+    strongs: v.strongs ?? [],
+    notes: v.notes ?? [],
+  }));
 }
 
 export async function getPassageHtml(


### PR DESCRIPTION
## Summary
- parse optional formatting metadata from the backend Bible JSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687432ad51ac8330a72e34421c0483c8